### PR TITLE
fix: sub-command region conflict with options_define region

### DIFF
--- a/tccli/argparser.py
+++ b/tccli/argparser.py
@@ -3,11 +3,13 @@
 
 import sys
 import argparse
+import collections
 from tccli.log import init
 import six
 from difflib import get_close_matches
 from gettext import gettext
 from tccli.error_msg import USAGE
+import tccli.options_define as OptionsDefine
 
 log = init("tccli.argparser")
 
@@ -22,7 +24,12 @@ class CustomAction(argparse.Action):
 
     @property
     def choices(self):
-        return list(self.command_map.keys())
+        cm = collections.OrderedDict()
+        for key, value in self.command_map.items():
+            if key == OptionsDefine.RegionServiceName:
+                key = OptionsDefine.RegionCommand
+            cm[key] = value
+        return list(cm.keys())
 
     @choices.setter
     def choices(self, val):

--- a/tccli/command.py
+++ b/tccli/command.py
@@ -46,6 +46,8 @@ class CLICommand(BaseCommand):
         self._handle_warning(args)
 
         parsed_args, remaining = parser.parse_known_args(args)
+        if parsed_args.command == Options_define.RegionCommand:
+            parsed_args.command = Options_define.RegionServiceName
         return command_map[parsed_args.command](remaining, parsed_args)
 
     def _handle_warning(self, args):

--- a/tccli/configure.py
+++ b/tccli/configure.py
@@ -52,11 +52,16 @@ class BasicConfigure(BasicCommand):
                     continue
                 conf_data[mod] = {}
                 conf_data[mod]["endpoint"] = "%s.tencentcloudapi.com" % mod
+                service = mod
                 # we have to do this because as is a keyword in python
                 # as has been changed to autoscaling only in python sdk & cli
                 if mod == 'autoscaling':
                     conf_data[mod]["endpoint"] = "as.tencentcloudapi.com"
-                versions = self._cli_data.get_service_all_version_actions(mod).keys()
+                # Fix configuration `region` key name conflict with region service(Region Management System)
+                elif mod == OptionsDefine.RegionServiceName:
+                    service = OptionsDefine.RegionCommand
+                    conf_data[mod]["endpoint"] = "region.tencentcloudapi.com"
+                versions = self._cli_data.get_service_all_version_actions(service).keys()
                 version = sorted(versions)[-1]
                 conf_data[mod]["version"] = version
         for k in extra.keys():

--- a/tccli/document_handler.py
+++ b/tccli/document_handler.py
@@ -1,5 +1,6 @@
 # -*- coding:utf-8 -*-
 
+import tccli.options_define as OptionsDefine
 from tccli.loaders import Loader, BASE_TYPE, CLI_BASE_TYPE
 
 
@@ -44,7 +45,7 @@ class CLIDocumentHandler(BaseDocumentHandler):
             self.doc.style.indent()
             self.doc.write(self.doc.style.spaces())
             for service in sorted(available_services):
-                self.doc.write("[%s] " % service)
+                self.doc.write("[%s] " % (service if service != OptionsDefine.RegionServiceName else OptionsDefine.RegionCommand))
             self.doc.style.dedent()
             self.doc.style.new_line()
             self.doc.style.new_line()
@@ -52,7 +53,7 @@ class CLIDocumentHandler(BaseDocumentHandler):
             self.doc.style.new_line()
         else:
             for service in sorted(available_services):
-                self.doc.doc_title_indent(service)
+                self.doc.doc_title_indent(service if service != OptionsDefine.RegionServiceName else OptionsDefine.RegionCommand)
                 version = self._cli_data.get_service_default_version(service)
                 description = self._cli_data.get_service_description(service, version)
                 if not description:

--- a/tccli/loaders.py
+++ b/tccli/loaders.py
@@ -4,6 +4,7 @@ import os
 import six
 import copy
 import json
+import tccli.options_define as OptionsDefine
 from tccli.utils import Utils
 from tccli import __version__
 from tccli.services import SERVICE_VERSIONS
@@ -180,6 +181,8 @@ class Loader(object):
         return self.get_available_services()[service][0]
 
     def get_service_model(self, service, version):
+        if service == OptionsDefine.RegionServiceName:
+            service = OptionsDefine.RegionCommand
         services_path = self.get_services_path()
         version = "v" + version.replace('-', '')
         apis_path = os.path.join(services_path, service, version, "api.json")

--- a/tccli/options_define.py
+++ b/tccli/options_define.py
@@ -42,5 +42,5 @@ Detail = "detail"
 ACTION_GLOBAL_OPT = [SecretId, SecretKey, Token, RoleArn, RoleSessionName, UseCVMRole, Region, Endpoint, Version, Language,
                      Filter, Profile, Timeout, Output, HttpsProxy, GenerateCliSkeleton, CliInputJson, CliUnfoldArgument, Waiter]
 
-
-
+RegionCommand = "region"
+RegionServiceName = "regionms"

--- a/tccli/services/__init__.py
+++ b/tccli/services/__init__.py
@@ -2,8 +2,12 @@
 import os
 import imp
 
+import tccli.options_define as OptionsDefine
+
 
 def action_caller(service):
+    if service == OptionsDefine.RegionServiceName:
+        service = OptionsDefine.RegionCommand
     cur_path = os.path.dirname(os.path.abspath(__file__))
     fp, pathname, desc = imp.find_module(service, [cur_path])
     mod = imp.load_module("tccli.services." + service, fp, pathname, desc)
@@ -502,7 +506,7 @@ SERVICE_VERSIONS = {
     "redis": [
         "2018-04-12"
     ],
-    "region": [
+    OptionsDefine.RegionServiceName: [
         "2022-06-27"
     ],
     "rkp": [

--- a/tccli/services/region/region_client.py
+++ b/tccli/services/region/region_client.py
@@ -262,11 +262,11 @@ def parse_global_arg(parsed_globals):
         if g_param[OptionsDefine.ServiceVersion]:
             g_param[OptionsDefine.Version] = "v" + g_param[OptionsDefine.ServiceVersion].replace('-', '')
         else:
-            version = conf["region"][OptionsDefine.Version]
+            version = conf[OptionsDefine.RegionServiceName][OptionsDefine.Version]
             g_param[OptionsDefine.Version] = "v" + version.replace('-', '')
 
         if g_param[OptionsDefine.Endpoint] is None:
-            g_param[OptionsDefine.Endpoint] = conf["region"][OptionsDefine.Endpoint]
+            g_param[OptionsDefine.Endpoint] = conf[OptionsDefine.RegionServiceName][OptionsDefine.Endpoint]
     except Exception as err:
         raise ConfigurationError("config file:%s error, %s" % (conf_path, str(err)))
 


### PR DESCRIPTION
```
$ rm -rf /root/.tccli/default.configure
$ tccli --version
3.0.924.1
$ tccli region  DescribeRegions  --Product cvm
usage: tccli [options] <command> <subcommand> [<subcommand> ...] [parameters]
To tccli help text, you can run:

  tccli help
  tccli configure help
  tccli service[cvm] help
  tccli service[cvm] action[RunInstances] help

config file:/root/.tccli/default.configure error, string indices must be integers

$ cat /root/.tccli/log/tccli.log
... ...
[2023-08-01 11:06:36,780] [4874] [tccli.main] [INFO] tccli region DescribeRegions --Product cvm
[2023-08-01 11:06:36,893] [4874] [tccli.main] [ERROR] config file:/root/.tccli/default.configure error, string indices must be integers
Traceback (most recent call last):
  File "/root/venv/lib/python3.6/site-packages/tccli/services/region/region_client.py", line 265, in parse_global_arg
    version = conf["region"][OptionsDefine.Version]
TypeError: string indices must be integers

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/venv/lib/python3.6/site-packages/tccli/main.py", line 41, in main
    CLICommand()()
  File "/root/venv/lib/python3.6/site-packages/tccli/command.py", line 49, in __call__
    return command_map[parsed_args.command](remaining, parsed_args)
  File "/root/venv/lib/python3.6/site-packages/tccli/command.py", line 189, in __call__
    return command_map[parsed_args.operation](remaining, parsed_globals)
  File "/root/venv/lib/python3.6/site-packages/tccli/command.py", line 286, in __call__
    return self._action_caller(action_parameters, vars(parsed_globals))
  File "/root/venv/lib/python3.6/site-packages/tccli/services/region/region_client.py", line 73, in doDescribeRegions
    g_param = parse_global_arg(parsed_globals)
  File "/root/venv/lib/python3.6/site-packages/tccli/services/region/region_client.py", line 271, in parse_global_arg
    raise ConfigurationError("config file:%s error, %s" % (conf_path, str(err)))
tccli.exceptions.ConfigurationError: config file:/root/.tccli/default.configure error, string indices must be integers
```

```
$ rm -rf /root/.tccli/default.configure
$ tccli --version
3.0.924.1
$ grep "region" /root/.tccli/default.configure
  "region": "ap-guangzhou",
```