### PR TITLE
feature/data-struct-self-ref-infinite-recursion

### DIFF
--- a/tccli/cli_unfold_argument.py
+++ b/tccli/cli_unfold_argument.py
@@ -16,7 +16,14 @@ class CliUnfoldArgument(CustomArgument):
     def __init__(self):
         super(CliUnfoldArgument, self).__init__(**self.ARG_DATA)
 
-    def build_action_parameters(self, args):
+    def build_action_parameters(self, args, extra_unfold_args=None):
+        """从 argparse Namespace 构造请求体。
+
+        :param args: argparse Namespace，扁平展开参数。
+        :param extra_unfold_args: 可选的额外扁平 ``{key: value}``，与 Namespace 合并后
+            一同走 ``convert_to_dict`` + ``handle_array``；为 ``None`` 或空时等同改动前。
+        :return: 嵌套 dict / list 形式的请求体。
+        """
         parsed_args = vars(args)
         for key in list(parsed_args.keys()):
             if parsed_args[key] is None:
@@ -24,6 +31,11 @@ class CliUnfoldArgument(CustomArgument):
         params_set = {}
         for key, value in parsed_args.items():
             self.convert_to_dict(params_set, key, value)
+        if extra_unfold_args:
+            for key, value in extra_unfold_args.items():
+                if value is None:
+                    continue
+                self.convert_to_dict(params_set, key, value)
         return self.handle_array(params_set, "--")
 
     def convert_to_dict(self, params_set, key, value):

--- a/tccli/cli_unfold_argument.py
+++ b/tccli/cli_unfold_argument.py
@@ -57,7 +57,7 @@ class CliUnfoldArgument(CustomArgument):
                 raise UnknownArgumentError(
                     "The index of the array parameter: %s must start from 0, "
                     "and the step size is 1" % parent_key)
-            params = list(params.values())
+            params = [params[k] for k in sorted(params.keys(), key=int)]
             for idx, item in enumerate(params):
                 prefix_param = parent_key+str(idx) if parent_key == "--" else parent_key+"."+str(idx)
                 params[idx] = self.handle_array(item, prefix_param)

--- a/tccli/command.py
+++ b/tccli/command.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import copy
+import six
 import tccli.services as Services
 import tccli.options_define as Options_define
 from collections import OrderedDict
@@ -319,7 +320,7 @@ class ActionCommand(BaseCommand):
             return help_command(remaining, parsed_globals)
         elif parsed_args.help:
             for idx, tok in enumerate(remaining):
-                if isinstance(tok, str) and tok.startswith("--"):
+                if isinstance(tok, six.string_types) and tok.startswith("--"):
                     remaining.insert(idx + 1, parsed_args.help)
                     break
             else:
@@ -394,7 +395,7 @@ class ActionCommand(BaseCommand):
 
         matched = OrderedDict()  # 命中的非法参数 -> (截断前缀, 自引用类型名)
         for token in remaining:
-            if not isinstance(token, str) or not token.startswith("--"):
+            if not isinstance(token, six.string_types) or not token.startswith("--"):
                 continue
             key = token[2:]
             for prefix, type_name in truncated.items():
@@ -468,7 +469,7 @@ class ActionCommand(BaseCommand):
                 key = tok[2:]
                 j = i + 1
                 paired = []
-                while j < n and isinstance(remaining[j], str) \
+                while j < n and isinstance(remaining[j], six.string_types) \
                         and not remaining[j].startswith("--"):
                     paired.append(remaining[j])
                     j += 1
@@ -628,7 +629,7 @@ class ActionCommand(BaseCommand):
                 i += 1
                 continue
             is_last = (i == n - 1)
-            next_is_opt = (not is_last) and isinstance(args[i + 1], str) \
+            next_is_opt = (not is_last) and isinstance(args[i + 1], six.string_types) \
                 and args[i + 1].startswith("--")
             if is_last or next_is_opt:
                 orphan_tokens.append(tok)

--- a/tccli/command.py
+++ b/tccli/command.py
@@ -326,7 +326,7 @@ class ActionCommand(BaseCommand):
                 remaining.append(parsed_args.help)
 
         extra_unfold_args = OrderedDict()
-        oversized_tokens = []  # [(key, depth, prefix, type_name)]
+        oversized_tokens = []  # [(key, depth)]
         if self._call_mode == Options_define.CliUnfoldArgument and remaining:
             remaining = self._extract_deep_nested_args(
                 remaining, extra_unfold_args, oversized_tokens)
@@ -342,7 +342,7 @@ class ActionCommand(BaseCommand):
                     "Input nesting depth exceeds MAX_INPUT_DEPTH=%d: %s"
                     % (MAX_INPUT_DEPTH,
                        ', '.join("--%s (depth=%d)" % (k, d)
-                                 for k, d, _p, _t in oversized_tokens)))
+                                 for k, d in oversized_tokens)))
             msg = "\n".join(error_parts)
             tail_hints = [h for h in (hint, oversized_hint) if h]
             if tail_hints:
@@ -436,7 +436,7 @@ class ActionCommand(BaseCommand):
 
         :param remaining: argparse 未识别 token 列表。
         :param extra_unfold_args: 输出，深度 ≤ MAX_INPUT_DEPTH 的 ``OrderedDict[key, value]``。
-        :param oversized_tokens: 输出，深度超限的 ``List[(key, depth, prefix, type_name)]``。
+        :param oversized_tokens: 输出，深度超限的 ``List[(key, depth)]``。
         :return: 剔除已消费 token 后剩余的未识别 token 列表。
         """
         if not remaining:
@@ -474,57 +474,71 @@ class ActionCommand(BaseCommand):
                     j += 1
                 has_eq, advance = False, 1 + len(paired)
 
-            # --- 最长前缀匹配 ---
-            prefix, type_name = self._match_truncated_prefix(key, truncated)
-            if prefix is None:
+            # 截断前缀只负责判断该 key 是否允许进入补偿链路。
+            if not self._is_recursive_key(key, truncated):
                 new_remaining.append(tok)
                 new_remaining.extend(paired)
                 i += advance
                 continue
 
-            # --- 取值 ---
-            if has_eq:
-                value = eq_value
-            elif paired:
-                value = paired[0] if len(paired) == 1 else paired
-            else:
+            # 深度限制优先于 schema 查询，超限参数无需加载和遍历 API 模型。
+            depth = sum(1 for seg in key.split(".") if not seg.isdigit())
+            if depth > MAX_INPUT_DEPTH:
+                oversized_tokens.append((key, depth))
+                i += advance
+                continue
+
+            if not has_eq and not paired:
                 new_remaining.append(tok)
                 i += advance
                 continue
-            if not isinstance(value, list):
-                if object_model is None:
-                    try:
-                        service_model = self._cli_data.get_service_model(
-                            self._service_name, self._version)
-                        object_model = service_model.get("objects", {})
-                    except Exception:
-                        object_model = {}
-                if self._is_deep_list_parameter(
-                        key, prefix, type_name, object_model):
-                    value = [value]
 
-            # --- 深度检查并分流 ---
-            depth = sum(1 for seg in key.split(".") if not seg.isdigit())
-            if depth > MAX_INPUT_DEPTH:
-                oversized_tokens.append((key, depth, prefix, type_name))
+            if object_model is None:
+                try:
+                    service_model = self._cli_data.get_service_model(
+                        self._service_name, self._version)
+                    object_model = service_model.get("objects", {})
+                except Exception:
+                    object_model = {}
+            shape = self._get_key_type(
+                key, self._action_name + "Request", object_model)
+            if shape is None:
+                new_remaining.append(tok)
+                new_remaining.extend(paired)
+                i += advance
+                continue
+
+            if has_eq:
+                value = [eq_value] if shape == "list" else eq_value
+            elif shape == "list":
+                value = paired
+            elif len(paired) == 1:
+                value = paired[0]
             else:
-                extra_unfold_args[key] = value
+                # 标量参数只接受一个值，保持未消费以沿用 Unknown options 错误路径。
+                new_remaining.append(tok)
+                new_remaining.extend(paired)
+                i += advance
+                continue
+
+            extra_unfold_args[key] = value
             i += advance
 
         return new_remaining
 
     @staticmethod
-    def _is_deep_list_parameter(key, prefix, type_name, object_model):
-        """判断自引用截断点以下的扁平参数是否对应 list 字段。"""
-        if not type_name or not object_model:
-            return False
-        suffix = key[len(prefix) + 1:].split(".")
-        current_type = type_name
-        for index, segment in enumerate(suffix):
+    def _get_key_type(key, root_type, object_model):
+        """查询完整扁平 key 的值形态，返回 ``list``、``scalar`` 或 ``None``。"""
+        if not key or not root_type or not object_model:
+            return None
+
+        segments = key.split(".")
+        current_type = root_type
+        index = 0
+        while index < len(segments):
+            segment = segments[index]
             if segment.isdigit():
-                if index == len(suffix) - 1:
-                    return False
-                continue
+                return None
 
             members = object_model.get(current_type, {}).get("members", [])
             if isinstance(members, dict):
@@ -533,27 +547,31 @@ class ActionCommand(BaseCommand):
                 member_info = next(
                     (item for item in members if item.get("name") == segment), None)
             if not member_info:
-                return False
+                return None
 
             member_type = str(member_info.get("type", "")).lower()
-            if index == len(suffix) - 1:
-                return member_type in ("list", "array")
-            if member_type not in ("list", "array", "object"):
-                return False
-            current_type = member_info.get("member")
-        return False
+            if index == len(segments) - 1:
+                return "list" if member_type in ("list", "array") else "scalar"
+
+            member = member_info.get("member")
+            if member_type in ("list", "array"):
+                index += 1
+                if index >= len(segments) or not segments[index].isdigit():
+                    return None
+                # 数组下标只能用于继续定位元素字段，不能作为完整 key 的末段。
+                if index == len(segments) - 1:
+                    return None
+
+            if member not in object_model:
+                return None
+            current_type = member
+            index += 1
+        return None
 
     @staticmethod
-    def _match_truncated_prefix(key, truncated):
-        """在 ``truncated`` 中按最长前缀匹配 ``key``，返回 ``(prefix, type_name)`` 或 ``(None, "")``。"""
-        best_prefix = None
-        best_type = ""
-        for prefix, type_name in truncated.items():
-            if key.startswith(prefix + ".") and \
-                    (best_prefix is None or len(prefix) > len(best_prefix)):
-                best_prefix = prefix
-                best_type = type_name
-        return best_prefix, best_type
+    def _is_recursive_key(key, truncated):
+        """判断 ``key`` 是否严格位于任一自引用截断前缀之下。"""
+        return any(key.startswith(prefix + ".") for prefix in truncated)
 
     def _build_oversized_hint(self, oversized_tokens):
         """为深度超限项构造错误提示文案，指向 --cli-input-json file://；空列表返回空串。"""
@@ -561,10 +579,9 @@ class ActionCommand(BaseCommand):
             return ""
         lines = ["Hint: the following option(s) exceed --cli-unfold-argument's "
                  "supported nesting depth (MAX_INPUT_DEPTH=%d):" % MAX_INPUT_DEPTH]
-        for key, depth, prefix, type_name in oversized_tokens:
-            lines.append("  --%s  (depth=%d, exceeds MAX_INPUT_DEPTH=%d, "
-                         "under --%s, type: %s)"
-                         % (key, depth, MAX_INPUT_DEPTH, prefix, type_name or "unknown"))
+        for key, depth in oversized_tokens:
+            lines.append("  --%s  (depth=%d, exceeds MAX_INPUT_DEPTH=%d)"
+                         % (key, depth, MAX_INPUT_DEPTH))
         lines.append("")
         lines.append("To pass this request:")
         lines.append("  " + RECURSIVE_HINT_FILE_OPTION)

--- a/tccli/command.py
+++ b/tccli/command.py
@@ -11,7 +11,8 @@ from tccli import credentials
 from tccli.utils import Utils
 from tccli.argument import CLIArgument, CustomArgument, ListArgument, BooleanArgument
 from tccli.exceptions import UnknownArgumentError
-from tccli.loaders import Loader
+from tccli.loaders import Loader, MAX_INPUT_DEPTH, RECURSIVE_HINT_FILE_OPTION
+from tccli.self_ref import is_action_self_referencing
 from tccli.argparser import CLIArgParser, ActionArgParser, ArgMapArgParser
 from tccli.help_command import CLIHelpCommand, ServiceHelpCommand, ActionHelpCommand
 from tccli.configure import ConfigureCommand
@@ -181,13 +182,16 @@ class ServiceCommand(BaseCommand):
             action_caller = action_model.get("action_caller", None)
             if not action_caller:
                 action_caller = Services.action_caller(self._service_name)()[action]
-            command_map[action] = ActionCommand(
+            cmd = ActionCommand(
                 service_name=self._service_name,
                 version=self._version,
                 action_name=action,
                 action_model=action_model,
                 action_caller=action_caller,
             )
+            cmd._is_self_ref = is_action_self_referencing(
+                self._service_name, self._version, action, service_model)
+            command_map[action] = cmd
         return command_map
 
     def __call__(self, args, parsed_globals):
@@ -230,6 +234,7 @@ class ActionCommand(BaseCommand):
         self.cli_input_argument = CliInputJSONArgument()
         self.cli_unfold_argument = CliUnfoldArgument()
         self.profile = "default"
+        self._is_self_ref = False
 
     @property
     def argument_map(self):
@@ -265,6 +270,8 @@ class ActionCommand(BaseCommand):
         return argument_map
 
     def __call__(self, args, parsed_globals):
+        if self._is_self_ref:
+            return self._call_with_depth_guard(args, parsed_globals)
 
         self._call_mode = self._get_call_mode(parsed_globals)
         self._get_profile(parsed_globals)
@@ -294,6 +301,66 @@ class ActionCommand(BaseCommand):
         credentials.maybe_refresh_credential(parsed_globals.profile if parsed_globals.profile else "default")
         return self._action_caller(action_parameters, vars(parsed_globals))
 
+    def _call_with_depth_guard(self, args, parsed_globals):
+        """Self-ref 接口专用入口：含 orphan key 过滤、深层嵌套提取、深度超限检测。"""
+
+        self._call_mode = self._get_call_mode(parsed_globals)
+        self._get_profile(parsed_globals)
+
+        action_parser = self._create_action_parser(self.argument_map)
+        action_parser.add_argument('help', nargs='?')
+
+        if self._call_mode == Options_define.CliUnfoldArgument:
+            self._prefilter_orphan_keys(args, action_parser)
+
+        parsed_args, remaining = action_parser.parse_known_args(args)
+        if parsed_args.help == 'help':
+            help_command = self.create_help_command()
+            return help_command(remaining, parsed_globals)
+        elif parsed_args.help:
+            for idx, tok in enumerate(remaining):
+                if isinstance(tok, str) and tok.startswith("--"):
+                    remaining.insert(idx + 1, parsed_args.help)
+                    break
+            else:
+                remaining.append(parsed_args.help)
+
+        extra_unfold_args = OrderedDict()
+        oversized_tokens = []  # [(key, depth, prefix, type_name)]
+        if self._call_mode == Options_define.CliUnfoldArgument and remaining:
+            remaining = self._extract_deep_nested_args(
+                remaining, extra_unfold_args, oversized_tokens)
+
+        if remaining or oversized_tokens:
+            hint = self._build_recursive_hint(remaining)
+            oversized_hint = self._build_oversized_hint(oversized_tokens)
+            error_parts = []
+            if remaining:
+                error_parts.append("Unknown options: %s" % ', '.join(remaining))
+            if oversized_tokens:
+                error_parts.append(
+                    "Input nesting depth exceeds MAX_INPUT_DEPTH=%d: %s"
+                    % (MAX_INPUT_DEPTH,
+                       ', '.join("--%s (depth=%d)" % (k, d)
+                                 for k, d, _p, _t in oversized_tokens)))
+            msg = "\n".join(error_parts)
+            tail_hints = [h for h in (hint, oversized_hint) if h]
+            if tail_hints:
+                msg += "\n\n" + "\n\n".join(tail_hints)
+            raise UnknownArgumentError(msg)
+
+        if self._call_mode == Options_define.GenerateCliSkeleton:
+            return self.generate_cli_skeleton_argument.generate_skeleton(parsed_globals)
+
+        if self._call_mode == Options_define.CliInputJson:
+            action_parameters = self.cli_input_argument.add_to_call_parameters(parsed_globals)
+        elif self._call_mode == Options_define.CliUnfoldArgument:
+            action_parameters = self.cli_unfold_argument.build_action_parameters(
+                parsed_args, extra_unfold_args=extra_unfold_args or None)
+        else:
+            action_parameters = self._build_action_parameters(parsed_args, self.argument_map)
+        credentials.maybe_refresh_credential(parsed_globals.profile if parsed_globals.profile else "default")
+        return self._action_caller(action_parameters, vars(parsed_globals))
     def create_help_command(self):
         return ActionHelpCommand(self._service_name, self._version, self._action_name)
 
@@ -306,6 +373,160 @@ class ActionCommand(BaseCommand):
                 value = parsed_args[name]
                 argument_object.add_to_params(action_params, value)
         return action_params
+
+    def _build_recursive_hint(self, remaining):
+        """为命中自引用截断前缀的未知参数生成提示文案，指向 --cli-input-json file://。"""
+        # 仅在 --cli-unfold-argument 模式下才有意义
+        if self._call_mode != Options_define.CliUnfoldArgument:
+            return ""
+        try:
+            unfold_params = self._cli_data.get_unfold_param_info(
+                self._service_name, self._version, self._action_name,
+                profile=self.profile, param_array=True)
+        except Exception:
+            return ""
+
+        # 收集所有被自引用截断的 leaf 前缀，例如：
+        #   "RuleList.RuleDetail.Children.0" -> "AllocationRuleExpression"
+        truncated = self._collect_truncated_prefixes(unfold_params)
+        if not truncated:
+            return ""
+
+        matched = OrderedDict()  # 命中的非法参数 -> (截断前缀, 自引用类型名)
+        for token in remaining:
+            if not isinstance(token, str) or not token.startswith("--"):
+                continue
+            key = token[2:]
+            for prefix, type_name in truncated.items():
+                # 严格前缀匹配："RuleList.RuleDetail.Children.0.RuleValue"
+                # 应被 "RuleList.RuleDetail.Children.0" 命中。
+                if key.startswith(prefix + "."):
+                    matched[token] = (prefix, type_name)
+                    break
+
+        if not matched:
+            return ""
+
+        lines = ["Hint: the following option(s) drill into a self-referencing type "
+                 "that --cli-unfold-argument cannot expand further:"]
+        for token, (prefix, type_name) in matched.items():
+            lines.append("  %s  (under --%s, self-referencing type: %s)"
+                         % (token, prefix, type_name or "unknown"))
+        lines.append("")
+        lines.append("To pass deeper nested values:")
+        lines.append("  " + RECURSIVE_HINT_FILE_OPTION)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _collect_truncated_prefixes(unfold_params):
+        """从 get_unfold_param_info 结果中收集自引用截断 leaf 前缀。
+
+        :return: ``OrderedDict[prefix_key, type_name]``，仅含 recursive_truncated 为 True 的项。
+        """
+        truncated = OrderedDict()
+        if not unfold_params:
+            return truncated
+        for name, info in unfold_params.items():
+            if info and info.get("recursive_truncated"):
+                truncated[name] = info.get("recursive_type") or ""
+        return truncated
+
+    def _extract_deep_nested_args(self, remaining, extra_unfold_args, oversized_tokens):
+        """从 ``remaining`` 提取命中自引用截断前缀的扁平参数并按深度分流。
+
+        :param remaining: argparse 未识别 token 列表。
+        :param extra_unfold_args: 输出，深度 ≤ MAX_INPUT_DEPTH 的 ``OrderedDict[key, value]``。
+        :param oversized_tokens: 输出，深度超限的 ``List[(key, depth, prefix, type_name)]``。
+        :return: 剔除已消费 token 后剩余的未识别 token 列表。
+        """
+        if not remaining:
+            return remaining
+        try:
+            unfold_params = self._cli_data.get_unfold_param_info(
+                self._service_name, self._version, self._action_name,
+                profile=self.profile, param_array=True)
+        except Exception:
+            return remaining
+        truncated = self._collect_truncated_prefixes(unfold_params)
+        if not truncated:
+            return remaining
+
+        new_remaining = []
+        i, n = 0, len(remaining)
+        while i < n:
+            tok = remaining[i]
+            # --- 内联 token 解析：支持 --key=value 和 --key v1 v2 两种形式 ---
+            if not isinstance(tok, str) or not tok.startswith("--"):
+                new_remaining.append(tok)
+                i += 1
+                continue
+            if "=" in tok:
+                key, eq_value = tok[2:].split("=", 1)
+                has_eq, paired, advance = True, [], 1
+            else:
+                key = tok[2:]
+                j = i + 1
+                paired = []
+                while j < n and isinstance(remaining[j], str) \
+                        and not remaining[j].startswith("--"):
+                    paired.append(remaining[j])
+                    j += 1
+                has_eq, advance = False, 1 + len(paired)
+
+            # --- 最长前缀匹配 ---
+            prefix, type_name = self._match_truncated_prefix(key, truncated)
+            if prefix is None:
+                new_remaining.append(tok)
+                new_remaining.extend(paired)
+                i += advance
+                continue
+
+            # --- 取值 ---
+            if has_eq:
+                value = eq_value
+            elif paired:
+                value = paired[0] if len(paired) == 1 else paired
+            else:
+                new_remaining.append(tok)
+                i += advance
+                continue
+
+            # --- 深度检查并分流 ---
+            depth = sum(1 for seg in key.split(".") if not seg.isdigit())
+            if depth > MAX_INPUT_DEPTH:
+                oversized_tokens.append((key, depth, prefix, type_name))
+            else:
+                extra_unfold_args[key] = value
+            i += advance
+
+        return new_remaining
+
+    @staticmethod
+    def _match_truncated_prefix(key, truncated):
+        """在 ``truncated`` 中按最长前缀匹配 ``key``，返回 ``(prefix, type_name)`` 或 ``(None, "")``。"""
+        best_prefix = None
+        best_type = ""
+        for prefix, type_name in truncated.items():
+            if key.startswith(prefix + ".") and \
+                    (best_prefix is None or len(prefix) > len(best_prefix)):
+                best_prefix = prefix
+                best_type = type_name
+        return best_prefix, best_type
+
+    def _build_oversized_hint(self, oversized_tokens):
+        """为深度超限项构造错误提示文案，指向 --cli-input-json file://；空列表返回空串。"""
+        if not oversized_tokens:
+            return ""
+        lines = ["Hint: the following option(s) exceed --cli-unfold-argument's "
+                 "supported nesting depth (MAX_INPUT_DEPTH=%d):" % MAX_INPUT_DEPTH]
+        for key, depth, prefix, type_name in oversized_tokens:
+            lines.append("  --%s  (depth=%d, exceeds MAX_INPUT_DEPTH=%d, "
+                         "under --%s, type: %s)"
+                         % (key, depth, MAX_INPUT_DEPTH, prefix, type_name or "unknown"))
+        lines.append("")
+        lines.append("To pass this request:")
+        lines.append("  " + RECURSIVE_HINT_FILE_OPTION)
+        return "\n".join(lines)
 
     def _get_profile(self, parsed_globals):
         if getattr(parsed_globals, Options_define.Profile):
@@ -326,3 +547,36 @@ class ActionCommand(BaseCommand):
     def _create_action_parser(self, argument_map):
         parser = ArgMapArgParser(argument_map)
         return parser
+
+    @staticmethod
+    def _prefilter_orphan_keys(args, action_parser):
+        """在 argparse 解析前扫描 args，检测无值的 --key 并抛错。"""
+        if not args:
+            return
+        valueless_opts = set()
+        for act in action_parser._actions:
+            if act.nargs == 0:
+                valueless_opts.update(act.option_strings)
+        orphan_tokens = []
+        n = len(args)
+        i = 0
+        while i < n:
+            tok = args[i]
+            if not isinstance(tok, str) or not tok.startswith("--") or "=" in tok:
+                i += 1
+                continue
+            if tok in valueless_opts:
+                i += 1
+                continue
+            is_last = (i == n - 1)
+            next_is_opt = (not is_last) and isinstance(args[i + 1], str) \
+                and args[i + 1].startswith("--")
+            if is_last or next_is_opt:
+                orphan_tokens.append(tok)
+            i += 1
+        if orphan_tokens:
+            raise UnknownArgumentError(
+                "Missing value for option(s): %s\n\n"
+                "Under --cli-unfold-argument mode, every --key must be immediately "
+                "followed by its value(s), or remove the key if you intend to leave it empty."
+                % ", ".join(orphan_tokens))

--- a/tccli/command.py
+++ b/tccli/command.py
@@ -458,7 +458,7 @@ class ActionCommand(BaseCommand):
         while i < n:
             tok = remaining[i]
             # --- 内联 token 解析：支持 --key=value 和 --key v1 v2 两种形式 ---
-            if not isinstance(tok, str) or not tok.startswith("--"):
+            if not isinstance(tok, six.string_types) or not tok.startswith("--"):
                 new_remaining.append(tok)
                 i += 1
                 continue
@@ -622,7 +622,7 @@ class ActionCommand(BaseCommand):
         i = 0
         while i < n:
             tok = args[i]
-            if not isinstance(tok, str) or not tok.startswith("--") or "=" in tok:
+            if not isinstance(tok, six.string_types) or not tok.startswith("--") or "=" in tok:
                 i += 1
                 continue
             if tok in valueless_opts:

--- a/tccli/command.py
+++ b/tccli/command.py
@@ -451,6 +451,7 @@ class ActionCommand(BaseCommand):
         if not truncated:
             return remaining
 
+        object_model = None
         new_remaining = []
         i, n = 0, len(remaining)
         while i < n:
@@ -490,6 +491,17 @@ class ActionCommand(BaseCommand):
                 new_remaining.append(tok)
                 i += advance
                 continue
+            if not isinstance(value, list):
+                if object_model is None:
+                    try:
+                        service_model = self._cli_data.get_service_model(
+                            self._service_name, self._version)
+                        object_model = service_model.get("objects", {})
+                    except Exception:
+                        object_model = {}
+                if self._is_deep_list_parameter(
+                        key, prefix, type_name, object_model):
+                    value = [value]
 
             # --- 深度检查并分流 ---
             depth = sum(1 for seg in key.split(".") if not seg.isdigit())
@@ -500,6 +512,36 @@ class ActionCommand(BaseCommand):
             i += advance
 
         return new_remaining
+
+    @staticmethod
+    def _is_deep_list_parameter(key, prefix, type_name, object_model):
+        """判断自引用截断点以下的扁平参数是否对应 list 字段。"""
+        if not type_name or not object_model:
+            return False
+        suffix = key[len(prefix) + 1:].split(".")
+        current_type = type_name
+        for index, segment in enumerate(suffix):
+            if segment.isdigit():
+                if index == len(suffix) - 1:
+                    return False
+                continue
+
+            members = object_model.get(current_type, {}).get("members", [])
+            if isinstance(members, dict):
+                member_info = members.get(segment)
+            else:
+                member_info = next(
+                    (item for item in members if item.get("name") == segment), None)
+            if not member_info:
+                return False
+
+            member_type = str(member_info.get("type", "")).lower()
+            if index == len(suffix) - 1:
+                return member_type in ("list", "array")
+            if member_type not in ("list", "array", "object"):
+                return False
+            current_type = member_info.get("member")
+        return False
 
     @staticmethod
     def _match_truncated_prefix(key, truncated):

--- a/tccli/document_handler.py
+++ b/tccli/document_handler.py
@@ -175,6 +175,14 @@ class ActionDocumentHandler(BaseDocumentHandler):
                     self.doc.write('[%s ...]' % (param_info["members"]))
                 else:
                     self.doc.doc_description('[%s ...]' % (param_info["members"]))
+            elif isinstance(param_info["members"], str):
+                # 自引用截断占位：members 为类型名字符串（如 "AllocationRuleExpression"），
+                # 直接渲染 recursive 提示占位，不再向下展开
+                placeholder = '[<recursive: fill with a JSON object of type %s, same shape as parent> ...]' % param_info["members"]
+                if self.doc.style.indentation > 2:
+                    self.doc.write(placeholder)
+                else:
+                    self.doc.doc_description(placeholder)
             else:
                 self.doc.write('[') if self.doc.style.indentation > 2 \
                     else self.doc.doc_description('[')
@@ -187,8 +195,15 @@ class ActionDocumentHandler(BaseDocumentHandler):
                 self.doc.style.new_line()
                 self.doc.doc_description(']')
         else:
-            if param_info["members"] not in BASE_TYPE:
-                self._handle_object_members(param_info["members"], param_info["type"])
+            if param_info["members"] in BASE_TYPE:
+                return
+            if isinstance(param_info["members"], str):
+                # 自引用截断占位（非 Array 形态）：members 为类型名字符串，
+                # 直接渲染 recursive 提示占位
+                self.doc.doc_description(
+                    '<recursive: fill with a JSON object of type %s, same shape as parent>' % param_info["members"])
+                return
+            self._handle_object_members(param_info["members"], param_info["type"])
 
     def _handle_object_members(self, param_info, param_type):
         if param_type == "Array" or self.doc.style.indentation == 2:
@@ -216,6 +231,9 @@ class ActionDocumentHandler(BaseDocumentHandler):
     def _unfold_complex_object(self, param_info):
         if not param_info["type"] == "Array" and param_info["members"] in BASE_TYPE:
             return
+        # 自引用截断占位：非 Array 且 members 为类型名字符串，无可展开内容，直接跳过
+        if not param_info["type"] == "Array" and isinstance(param_info["members"], str):
+            return
 
         self.doc.style.new_line()
         self.doc.doc_title('JSON Syntax')
@@ -232,13 +250,18 @@ class ActionDocumentHandler(BaseDocumentHandler):
     def _complex_object_doc(self, param_info, option):
         if param_info["members"] in BASE_TYPE:
             return
+        # 自引用截断占位：members 为类型名字符串，无子成员可遍历，直接返回
+        if not isinstance(param_info["members"], dict):
+            return
         self.doc.style.indent()
         for sub_param, sub_param_info in param_info["members"].items():
             self.doc.style.new_line()
             self._doc_title(option, sub_param, sub_param_info)
             self.doc.doc_description('%s' % sub_param_info["document"])
             self.doc.style.new_line()
-            if sub_param_info["members"] not in BASE_TYPE:
+            # 仅当子成员的 members 仍然是 dict（即未被截断且非基础类型）时才继续递归
+            if sub_param_info["members"] not in BASE_TYPE \
+                    and isinstance(sub_param_info["members"], dict):
                 self._complex_object_doc(sub_param_info, option)
         self.doc.style.dedent()
         self.doc.style.new_line()

--- a/tccli/document_handler.py
+++ b/tccli/document_handler.py
@@ -1,7 +1,7 @@
 # -*- coding:utf-8 -*-
 
 from tccli.loaders import Loader, BASE_TYPE, CLI_BASE_TYPE
-
+import six
 
 class BaseDocumentHandler(object):
     def __init__(self, doc):
@@ -175,7 +175,7 @@ class ActionDocumentHandler(BaseDocumentHandler):
                     self.doc.write('[%s ...]' % (param_info["members"]))
                 else:
                     self.doc.doc_description('[%s ...]' % (param_info["members"]))
-            elif isinstance(param_info["members"], str):
+            elif isinstance(param_info["members"], six.string_types):
                 # 自引用截断占位：members 为类型名字符串（如 "AllocationRuleExpression"），
                 # 直接渲染 recursive 提示占位，不再向下展开
                 placeholder = '[<recursive: fill with a JSON object of type %s, same shape as parent> ...]' % param_info["members"]
@@ -197,7 +197,7 @@ class ActionDocumentHandler(BaseDocumentHandler):
         else:
             if param_info["members"] in BASE_TYPE:
                 return
-            if isinstance(param_info["members"], str):
+            if isinstance(param_info["members"], six.string_types):
                 # 自引用截断占位（非 Array 形态）：members 为类型名字符串，
                 # 直接渲染 recursive 提示占位
                 self.doc.doc_description(
@@ -232,7 +232,7 @@ class ActionDocumentHandler(BaseDocumentHandler):
         if not param_info["type"] == "Array" and param_info["members"] in BASE_TYPE:
             return
         # 自引用截断占位：非 Array 且 members 为类型名字符串，无可展开内容，直接跳过
-        if not param_info["type"] == "Array" and isinstance(param_info["members"], str):
+        if not param_info["type"] == "Array" and isinstance(param_info["members"], six.string_types):
             return
 
         self.doc.style.new_line()

--- a/tccli/loaders.py
+++ b/tccli/loaders.py
@@ -648,7 +648,7 @@ class Loader(object):
                 if not isinstance(members_container, dict) or item not in members_container:
                     # 该 leaf 是被环检测截断的占位项，不再向下钻取
                     recursive_truncated = True
-                    recursive_type = members_container if isinstance(members_container, str) \
+                    recursive_type = members_container if isinstance(members_container, six.string_types) \
                         else (res.get("type_name") or "")
                     break
                 res = members_container[item]
@@ -667,12 +667,12 @@ class Loader(object):
             if not recursive_truncated:
                 final_members = res.get("members")
                 if isinstance(final_members, list) and len(final_members) == 1 \
-                        and isinstance(final_members[0], str) \
+                        and isinstance(final_members[0], six.string_types) \
                         and final_members[0] not in BASE_TYPE \
                         and final_members[0] not in CLI_BASE_TYPE:
                     recursive_truncated = True
                     recursive_type = final_members[0]
-                elif isinstance(final_members, str) \
+                elif isinstance(final_members, six.string_types) \
                         and final_members not in BASE_TYPE \
                         and final_members not in CLI_BASE_TYPE:
                     recursive_truncated = True
@@ -726,8 +726,11 @@ class Loader(object):
         return examples
 
     def translate_cli_example(self, module, action, example):
-        if example["input"].startswith("https"):
-            input_param_list = example["input"].replace(u"&<公共请求参数>", "").split("&")[1:]
+        example_input = example["input"]
+        if isinstance(example_input, bytes):
+            example_input = example_input.decode("utf-8")
+        if example_input.startswith("https"):
+            input_param_list = example_input.replace(u"&<公共请求参数>", "").split("&")[1:]
             return self.translate_get_cli_param(input_param_list)
         elif example["input"].startswith("POST"):
             input_param = example["input"].split('\n\n')[-1]
@@ -782,7 +785,7 @@ class Loader(object):
     def _translate_post_cli_param(self, input_param, param_list, all_param_list):
         # basic type
         if not isinstance(input_param, list) and not isinstance(input_param, dict):
-            if isinstance(input_param, str) and " " in input_param:
+            if isinstance(input_param, six.string_types) and " " in input_param:
                 input_param = "'" + input_param + "'"
             param_list.append(str(input_param))
             tmp = copy.deepcopy(param_list)

--- a/tccli/loaders.py
+++ b/tccli/loaders.py
@@ -10,9 +10,21 @@ from tccli import __version__
 from tccli.services import SERVICE_VERSIONS
 from collections import OrderedDict
 import tccli.plugin as plugin
+from tccli.self_ref import is_action_self_referencing
 
 BASE_TYPE = ["int64", "uint64", "string", "float", "bool", "date", "datetime", "datetime_iso", "binary"]
 CLI_BASE_TYPE = ["Integer", "String", "Float", "Timestamp", "Boolean", "Binary"]
+
+# --cli-unfold-argument 模式下扁平 key 的最大点号段数（含数字下标段），超过则报错。
+MAX_INPUT_DEPTH = 30
+
+# 自引用截断点 / 超限输入的统一替代写法提示文案。
+RECURSIVE_HINT_FILE_OPTION = (
+    "Use --cli-input-json file://<path/to/request.json> to provide the entire "
+    "request as a JSON file (the value must begin with 'file://'; raw JSON "
+    "strings are not accepted; run with --generate-cli-skeleton to get a JSON "
+    "template)."
+)
 
 PARAM_TYPE_MAP = {
     'int64': 'Integer',
@@ -353,15 +365,63 @@ class Loader(object):
                     self._filling_param_info(param_info, para, para["member"], para["member"])
         return param_info
 
+    def _get_param_info_safe(self, param_model, object_model, visited=None):
+        # 【自引用数据结构专属链路】仅自引用接口经 dispatch 进入，非自引用接口不会走到。
+        # visited 沿当前 DFS 路径记录已展开的复合类型名，命中即截断
+        if visited is None:
+            visited = frozenset()
+        param_info = {}
+        for para in param_model:
+            member = para["member"]
+            recursive_hit = member not in BASE_TYPE and member in visited
+            if para["type"] == "list":
+                if member not in BASE_TYPE:
+                    if recursive_hit:
+                        self._filling_param_info(
+                            param_info, para, "list", [member])
+                    else:
+                        self._filling_param_info(
+                            param_info, para, "list",
+                            [self._get_param_info_safe(
+                                object_model[member]["members"], object_model,
+                                visited | {member})])
+                else:
+                    self._filling_param_info(
+                        param_info, para, "list", [member])
+            else:
+                if member not in BASE_TYPE:
+                    if recursive_hit:
+                        param_info = self._filling_param_info(
+                            param_info, para, member, member)
+                    else:
+                        param_info = self._filling_param_info(
+                            param_info, para, member,
+                            self._get_param_info_safe(
+                                object_model[member]["members"], object_model,
+                                visited | {member}))
+                else:
+                    self._filling_param_info(param_info, para, member, member)
+        return param_info
+
     def get_param_info(self, service, version, action):
         service_model = self.get_service_model(service, version)
         param_model = service_model["objects"]
-        return self._get_param_info(param_model[action + "Request"]["members"], param_model)
+        if is_action_self_referencing(service, version, action, service_model):
+            return self._get_param_info_safe(
+                param_model[action + "Request"]["members"], param_model)
+        return self._get_param_info(
+            param_model[action + "Request"]["members"], param_model)
 
     def get_output_param_info(self, service, version, action):
         service_model = self.get_service_model(service, version)
         param_model = service_model["objects"]
-        return self._get_param_info(param_model[action + "Response"]["members"], param_model)
+        # 输出侧走 Response 类型图，其环结构可能与 Request 不同，必须独立判定
+        if is_action_self_referencing(service, version, action, service_model,
+                                      root_suffix="Response"):
+            return self._get_param_info_safe(
+                param_model[action + "Response"]["members"], param_model)
+        return self._get_param_info(
+            param_model[action + "Response"]["members"], param_model)
 
     def _generate_param_skeleton(self, param_model, name):
         param_skeleton = {}
@@ -380,14 +440,66 @@ class Loader(object):
                     param_skeleton[para["name"]] = PARAM_TYPE_MAP[para["member"]]
         return param_skeleton
 
+    def _generate_param_skeleton_safe(self, param_model, name, visited=None):
+        # 【自引用数据结构专属链路】仅自引用接口经 dispatch 进入，非自引用接口不会走到。
+        # visited 沿路径记录已展开的复合类型名，命中即以字符串占位表示自引用
+        if visited is None:
+            visited = frozenset()
+        param_skeleton = {}
+        for para in param_model:
+            member = para["member"]
+            recursive_hit = member not in BASE_TYPE and member in visited
+            if para["type"] == "list":
+                if member not in BASE_TYPE:
+                    if recursive_hit:
+                        param_skeleton[para["name"]] = [
+                            "<recursive: fill '%s' with a JSON object of type %s (self-referenced)>"
+                            % (para["name"], member)]
+                    else:
+                        param_skeleton[para["name"]] = \
+                            [self._generate_param_skeleton_safe(
+                                name[member]["members"], name,
+                                visited | {member})]
+                else:
+                    param_skeleton[para["name"]] = [PARAM_TYPE_MAP[member]]
+            else:
+                if member not in BASE_TYPE:
+                    if recursive_hit:
+                        param_skeleton[para["name"]] = \
+                            "<recursive: fill '%s' with a JSON object of type %s (self-referenced)>" \
+                            % (para["name"], member)
+                    else:
+                        param_skeleton[para["name"]] = \
+                            self._generate_param_skeleton_safe(
+                                name[member]["members"], name,
+                                visited | {member})
+                else:
+                    param_skeleton[para["name"]] = PARAM_TYPE_MAP[member]
+        return param_skeleton
+
     def generate_param_skeleton(self, service, version, action):
         service_model = self.get_service_model(service, version)
         param_model = service_model["objects"]
-        return self._generate_param_skeleton(param_model[action + "Request"]["members"], param_model)
+        if is_action_self_referencing(service, version, action, service_model):
+            return self._generate_param_skeleton_safe(
+                param_model[action + "Request"]["members"], param_model)
+        return self._generate_param_skeleton(
+            param_model[action + "Request"]["members"], param_model)
 
     def get_unfold_param_info(self, service, version, action, profile="default", param_array=False):
         service_model = self.get_service_model(service, version)
         object_model = service_model["objects"]
+
+        if is_action_self_referencing(service, version, action, service_model):
+            all_param_list = []
+            for para in object_model[action + "Request"]["members"]:
+                param_list = []
+                self._get_unfold_param_info_safe(object_model, all_param_list, param_list, para)
+            if param_array:
+                all_param_list = self._add_array_item(all_param_list, profile)
+            return self._filling_unfold_param_info_safe(
+                all_param_list, service, version, action, object_model)
+
         all_param_list = []
         for para in object_model[action + "Request"]["members"]:
             param_list = []
@@ -421,6 +533,14 @@ class Loader(object):
         if param_list.pop().isdigit():
             param_list.pop()
 
+    def _recur_get_unfold_param_info_safe(self, param_model, object_model, return_param_list, param_list,
+                                          visited=None):
+        # 【自引用数据结构专属链路】仅自引用接口经 dispatch 进入，非自引用接口不会走到。
+        for para in param_model:
+            self._get_unfold_param_info_safe(object_model, return_param_list, param_list, para, visited)
+        if param_list.pop().isdigit():
+            param_list.pop()
+
     def _get_unfold_param_info(self, object_model, return_param_list, param_list, para):
         param_list.append(para["name"])
         if para["type"] == "list" and para["member"] not in BASE_TYPE:
@@ -428,6 +548,32 @@ class Loader(object):
         if para["member"] not in BASE_TYPE:
             self._recur_get_unfold_param_info(object_model[para["member"]]["members"],
                                               object_model, return_param_list, param_list)
+        else:
+            tmp = copy.deepcopy(param_list)
+            return_param_list.append(tmp)
+
+            if param_list.pop().isdigit():
+                param_list.pop()
+
+    def _get_unfold_param_info_safe(self, object_model, return_param_list, param_list, para, visited=None):
+        # 【自引用数据结构专属链路】仅自引用接口经 dispatch 进入，非自引用接口不会走到。
+        # visited 沿路径维护，识别自引用类型（如 AllocationRuleExpression.Children）
+        if visited is None:
+            visited = frozenset()
+        param_list.append(para["name"])
+        if para["type"] == "list" and para["member"] not in BASE_TYPE:
+            param_list.append('0')
+        member = para["member"]
+        if member not in BASE_TYPE:
+            if member in visited:
+                tmp = copy.deepcopy(param_list)
+                return_param_list.append(tmp)
+                if param_list.pop().isdigit():
+                    param_list.pop()
+                return
+            self._recur_get_unfold_param_info_safe(object_model[member]["members"],
+                                                   object_model, return_param_list, param_list,
+                                                   visited | {member})
         else:
             tmp = copy.deepcopy(param_list)
             return_param_list.append(tmp)
@@ -473,6 +619,88 @@ class Loader(object):
             unfold_param[".".join(param)]["type_name"] = type_name
             unfold_param[".".join(param)]["required"] = required
             unfold_param[".".join(param)]["document"] = document
+        return unfold_param
+
+    def _filling_unfold_param_info_safe(self, param_list, service, version, action, object_model=None):
+        # 【自引用数据结构专属链路】仅自引用接口经 dispatch 进入，非自引用接口不会走到。
+        # 相比原始版额外识别被截断的 leaf，打上 recursive_truncated / recursive_type 标记。
+        unfold_param = {}
+        param_info = self.get_param_info(service, version, action)
+        for param in param_list:
+            unfold_param[".".join(param)] = {}
+
+            tmp_param = [item for item in param if not item.isdigit()]
+            res = param_info[tmp_param[0]]
+
+            param_type = res["type"]
+            type_name = res["type_name"]
+            required = res.get("required")
+            document = res["document"]
+            recursive_truncated = False
+            recursive_type = None
+
+            for idx, item in enumerate(tmp_param[1:]):
+                # 命中自引用截断：当前 res 的 members 是占位字符串（类型名）而非 dict
+                if res["type"] == "Array":
+                    members_container = res["members"][0]
+                else:
+                    members_container = res["members"]
+                if not isinstance(members_container, dict) or item not in members_container:
+                    # 该 leaf 是被环检测截断的占位项，不再向下钻取
+                    recursive_truncated = True
+                    recursive_type = members_container if isinstance(members_container, str) \
+                        else (res.get("type_name") or "")
+                    break
+                res = members_container[item]
+
+                if required == "Required" and res["required"] == "Optional":
+                    required = "Optional"
+
+                if idx == len(tmp_param) - 2:
+                    param_type = res["type"]
+                    type_name = res["type_name"] if res["type"] == "Array" \
+                        else res["type_name"]
+                    document = res["document"]
+                    break
+
+            # 二次判定：路径走完后，若该 leaf 自身是被环检测截断的复合类型（members 为占位）
+            if not recursive_truncated:
+                final_members = res.get("members")
+                if isinstance(final_members, list) and len(final_members) == 1 \
+                        and isinstance(final_members[0], str) \
+                        and final_members[0] not in BASE_TYPE \
+                        and final_members[0] not in CLI_BASE_TYPE:
+                    recursive_truncated = True
+                    recursive_type = final_members[0]
+                elif isinstance(final_members, str) \
+                        and final_members not in BASE_TYPE \
+                        and final_members not in CLI_BASE_TYPE:
+                    recursive_truncated = True
+                    recursive_type = final_members
+
+            if len([item for item in param if item.isdigit() and int(item) > 0]) > 0:
+                required = "Optional"
+
+            if recursive_truncated:
+                # 自引用截断点统一标记为 Object，提示用户用 JSON 整体传入
+                param_type = "Object"
+                type_name = recursive_type or "Object"
+                required = "Optional"
+                document = (document or "") + \
+                    ("\nNote: this field is a self-referencing type %s. "
+                     "--cli-unfold-argument only expands the first level. "
+                     "For deeper nesting:\n  %s"
+                     % (recursive_type or "", RECURSIVE_HINT_FILE_OPTION))
+
+            unfold_param[".".join(param)]["type"] = param_type
+            unfold_param[".".join(param)]["type_name"] = type_name
+            unfold_param[".".join(param)]["required"] = required
+            unfold_param[".".join(param)]["document"] = document
+            # 稳定字段：供上层（如 command.py）在客户深入自引用路径报 Unknown options 时
+            # 给出针对性提示，无需依赖 document 文案
+            if recursive_truncated:
+                unfold_param[".".join(param)]["recursive_truncated"] = True
+                unfold_param[".".join(param)]["recursive_type"] = recursive_type or ""
         return unfold_param
 
     def get_action_example_model(self, service, version, action):

--- a/tccli/loaders.py
+++ b/tccli/loaders.py
@@ -15,7 +15,7 @@ from tccli.self_ref import is_action_self_referencing
 BASE_TYPE = ["int64", "uint64", "string", "float", "bool", "date", "datetime", "datetime_iso", "binary"]
 CLI_BASE_TYPE = ["Integer", "String", "Float", "Timestamp", "Boolean", "Binary"]
 
-# --cli-unfold-argument 模式下扁平 key 的最大点号段数（含数字下标段），超过则报错。
+# --cli-unfold-argument 模式下扁平 key 的最大非数字段数（数字下标段不计），超过则报错。
 MAX_INPUT_DEPTH = 30
 
 # 自引用截断点 / 超限输入的统一替代写法提示文案。

--- a/tccli/self_ref.py
+++ b/tccli/self_ref.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+"""自引用类型图检测器。
+
+检测某个 action 的类型图中是否存在环（自引用或相互引用的复合类型）。
+
+口径契约（隔离边界的单一事实来源）：
+  - 输入侧（command 的 ``__call__`` 分发、``get_param_info``、
+    ``generate_param_skeleton``、``get_unfold_param_info``）必须通过默认的
+    ``root_suffix="Request"`` 检测 ``Request`` 类型图。
+  - 输出侧（``get_output_param_info``）必须通过 ``root_suffix="Response"``
+    检测 ``Response`` 类型图，因为两侧的图结构可能不同。
+  - 出现任何异常时一律回退为 ``False``（宁可漏判——由测试用例兜底，也不误判——
+    误判会改变稳定路径的行为）。
+"""
+
+BASE_TYPE = frozenset([
+    "int64", "uint64", "string", "float", "bool",
+    "date", "datetime", "datetime_iso", "binary",
+])
+
+
+def _dfs_has_cycle(objects, type_name, path_visited):
+    """从 ``type_name`` 出发对 ``objects`` 做 DFS 以检测环。
+    
+    :param objects: 类型图，形如 ``类型名 -> {"members": [{...}, ...]}``。
+    :param type_name: 当前待检查的类型名。
+    :param path_visited: 当前 DFS 路径上已访问过的类型名集合（frozenset）。
+    :return: 若发现环则返回 True。
+    """
+    # 坏数据（类型缺失 / members 非法）在此自然抛异常，由外层 is_action_self_referencing 的
+    # try/except 统一兜底为 False，故此处只专注判环逻辑，不做防御性判断。
+    for member in objects[type_name]["members"]:
+        ref_name = member.get("member")  # 该字段引用的类型名
+        if not ref_name or ref_name in BASE_TYPE:  # 基础类型是叶子，剪枝
+            continue
+        if ref_name in path_visited:  # 绕回当前路径上的类型 → 有环
+            return True
+        # 深入子类型；新建集合保证各 DFS 分支路径独立、互不污染
+        if _dfs_has_cycle(objects, ref_name, path_visited | {ref_name}):
+            return True
+    return False
+
+
+def is_action_self_referencing(service, version, action, service_model,
+                               root_suffix="Request"):
+    """判断某个 ``action`` 的类型图中是否存在自引用环。
+
+    :param service: 服务名。
+    :param version: 版本号（如 "2017-03-12"）。
+    :param action: 接口名。
+    :param service_model: 完整的 service model 字典，需含 "objects" 键。
+    :param root_suffix: 待检测的根类型后缀，``"Request"``（输入图，默认）
+        或 ``"Response"``（输出图）。两侧图结构可能不同，
+        因此渲染输出的调用方必须显式传入 ``"Response"``。
+    :return: 若对应类型图存在环则返回 True。
+    """
+    try:
+        objects = service_model.get("objects", {})
+        root_type_name = action + root_suffix
+        return _dfs_has_cycle(objects, root_type_name, frozenset([root_type_name]))
+    except Exception:
+        return False

--- a/tests/test_cli_unfold_argument.py
+++ b/tests/test_cli_unfold_argument.py
@@ -1,0 +1,309 @@
+# -*- coding:utf-8 -*-
+"""
+recursive-nesting-30：CliUnfoldArgument 单元测试。
+
+覆盖目标：
+  1. ``convert_to_dict`` 对任意深度（含 30 段自引用 / D=61）的扁平 key 仍能正确
+     构造嵌套 dict；
+  2. ``handle_array`` 对纯数字键正确转 list、对混合键报错；
+  3. ``build_action_parameters`` 接受可选 ``extra_unfold_args`` 时，能把它和已注册
+     的 argparse Namespace 合并；``None`` / 空 dict 行为与改动前一致；
+  4. 红线（需求 1.4）：输出嵌套不补 None / 空 dict。
+
+注意：本文件不依赖任何 services/*/v*/api.json，便于 CI 在仓库瘦身后仍可运行。
+"""
+
+import argparse
+
+import pytest
+
+from tccli.cli_unfold_argument import CliUnfoldArgument
+from tccli.exceptions import UnknownArgumentError
+
+
+# ============================================================
+# 工具：用 argparse.Namespace 模拟 argparse 解析后的扁平参数
+# ============================================================
+def _ns(**kwargs):
+    """构造 ``argparse.Namespace``，其 ``__dict__`` 即 ``vars(ns)``。"""
+    return argparse.Namespace(**kwargs)
+
+
+def _build_unfold_arg():
+    return CliUnfoldArgument()
+
+
+# ============================================================
+# A. convert_to_dict 基本行为
+# ============================================================
+def test_A1_convert_to_dict_simple_flat_key():
+    """A1: 单段 key 直接落到 params_set 顶层。"""
+    arg = _build_unfold_arg()
+    bag = {}
+    arg.convert_to_dict(bag, "Foo", "v")
+    assert bag == {"Foo": "v"}
+
+
+def test_A2_convert_to_dict_two_level():
+    """A2: 两段 key 递归创建一层 dict。"""
+    arg = _build_unfold_arg()
+    bag = {}
+    arg.convert_to_dict(bag, "A.B", "v")
+    assert bag == {"A": {"B": "v"}}
+
+
+def test_A3_convert_to_dict_with_array_index():
+    """A3: 含数字段的 key 在 convert_to_dict 阶段仍是 dict，依赖 handle_array 转 list。"""
+    arg = _build_unfold_arg()
+    bag = {}
+    arg.convert_to_dict(bag, "A.0.B", "v")
+    assert bag == {"A": {"0": {"B": "v"}}}
+
+
+# ============================================================
+# B. convert_to_dict 在 D=5 / D=7 / D=61（30 段自引用）三档的正确性
+# ============================================================
+def _build_self_ref_keys(num_levels):
+    """构造 ``num_levels`` 段自引用扁平 key。
+
+    每段为 ``Children.0``，整体形如 ``Children.0.Children.0...LeafField``。
+    返回 (key, depth)。
+    """
+    parts = ["Children", "0"] * num_levels + ["LeafField"]
+    key = ".".join(parts)
+    return key, len(parts)
+
+
+def test_B3_convert_to_dict_depth_61_self_ref_30_levels():
+    """B3: 30 段自引用（D=61）能正确构造嵌套；不会触发递归限制。"""
+    key, depth = _build_self_ref_keys(30)
+    assert depth == 61
+
+    arg = _build_unfold_arg()
+    bag = {}
+    arg.convert_to_dict(bag, key, "deep_value")
+
+    # 顺着 30 层 Children/0 走到末端 LeafField
+    cursor = bag
+    for _ in range(30):
+        assert "Children" in cursor
+        cursor = cursor["Children"]
+        assert "0" in cursor
+        cursor = cursor["0"]
+    assert cursor == {"LeafField": "deep_value"}
+
+
+# ============================================================
+# C. handle_array 配套行为：30 层自引用经 handle_array 后 list 下标对齐
+# ============================================================
+def test_C1_handle_array_depth_61_no_padding():
+    """C1: D=61 经 handle_array 后嵌套结构仍然不补 None / 空 dict（红线 1.4）。"""
+    key, _ = _build_self_ref_keys(30)
+    arg = _build_unfold_arg()
+    bag = {}
+    arg.convert_to_dict(bag, key, "deep_value")
+    out = arg.handle_array(bag, "--")
+
+    # 期望：每一层都是 {"Children": [{...}]}（list 长度 1，下标 0）
+    cursor = out
+    for _ in range(30):
+        assert isinstance(cursor, dict)
+        assert "Children" in cursor
+        children = cursor["Children"]
+        assert isinstance(children, list)
+        assert len(children) == 1, "list 应严格只有下标 0，不补 None"
+        cursor = children[0]
+    # 末端是 dict 而非 None
+    assert cursor == {"LeafField": "deep_value"}
+
+
+def test_C2_handle_array_rejects_non_consecutive_index():
+    """C2: handle_array 对不连续下标（1 而无 0）按既有约定报错——回归保护，不应受本次改动影响。"""
+    arg = _build_unfold_arg()
+    bag = {"A": {"1": "v"}}  # 缺少 "0"
+    with pytest.raises(UnknownArgumentError):
+        arg.handle_array(bag, "--")
+
+
+# ============================================================
+# D. build_action_parameters 接收 extra_unfold_args 注入
+# ============================================================
+def test_D1_build_action_parameters_without_extra_args_unchanged():
+    """D1: 不传 extra_unfold_args 时与改动前完全一致。"""
+    arg = _build_unfold_arg()
+    ns = _ns(**{"A.0.B": "v", "A.1.B": "w"})
+    out = arg.build_action_parameters(ns)
+    assert out == {"A": [{"B": "v"}, {"B": "w"}]}
+
+
+def test_D2_build_action_parameters_with_none_extra_args_unchanged():
+    """D2: 传 None / 空 dict 行为同 D1。"""
+    arg = _build_unfold_arg()
+    ns = _ns(**{"A.0.B": "v"})
+    assert arg.build_action_parameters(ns, extra_unfold_args=None) == {"A": [{"B": "v"}]}
+    assert arg.build_action_parameters(_ns(**{"A.0.B": "v"}), extra_unfold_args={}) \
+        == {"A": [{"B": "v"}]}
+
+
+def test_D3_build_action_parameters_extra_args_merge_with_namespace():
+    """D3: extra_unfold_args 与 Namespace 合并构造同一个嵌套结构（D=5）。"""
+    arg = _build_unfold_arg()
+    ns = _ns(**{"Outer.Inner": "registered"})
+    extra = {"Outer.Deep.0.X": "v1", "Outer.Deep.0.Y": "v2"}
+    out = arg.build_action_parameters(ns, extra_unfold_args=extra)
+    assert out == {
+        "Outer": {
+            "Inner": "registered",
+            "Deep": [{"X": "v1", "Y": "v2"}],
+        },
+    }
+
+
+def test_D4_build_action_parameters_extra_args_depth_61():
+    """D4: extra_unfold_args 单独承载 D=61 的扁平 key，仍能正确构造 30 层嵌套。
+
+    端到端覆盖路径：未注册到 argparse 的深嵌套 key → 由 command.py 兜底分支收集 →
+    经 build_action_parameters(extra_unfold_args=...) → convert_to_dict + handle_array
+    输出请求体。
+    """
+    key, _ = _build_self_ref_keys(30)
+    arg = _build_unfold_arg()
+    ns = _ns()  # 空 Namespace —— Namespace 自身只能挂注册过的扁平 key
+    out = arg.build_action_parameters(ns, extra_unfold_args={key: "deep_value"})
+
+    cursor = out
+    for _ in range(30):
+        assert isinstance(cursor, dict)
+        assert "Children" in cursor
+        children = cursor["Children"]
+        assert isinstance(children, list) and len(children) == 1
+        cursor = children[0]
+    assert cursor == {"LeafField": "deep_value"}
+
+
+def test_D5_build_action_parameters_extra_args_skip_none_values():
+    """D5: extra_unfold_args 中 value 为 None 的项被跳过（与 Namespace 行为一致）。"""
+    arg = _build_unfold_arg()
+    ns = _ns()
+    out = arg.build_action_parameters(
+        ns,
+        extra_unfold_args={"A.0.B": "v", "A.0.C": None},
+    )
+    assert out == {"A": [{"B": "v"}]}
+
+
+# ============================================================
+# E. 旧版兼容路径（build_action_parameters_old / gen_param_dict / merge_dict）
+# ============================================================
+def test_E1_gen_param_dict_simple_flat_key():
+    """E1: gen_param_dict 处理单段 key。"""
+    arg = _build_unfold_arg()
+    out = arg.gen_param_dict({"Foo": "v"})
+    assert out == [{"Foo": "v"}]
+
+
+def test_E2_gen_param_dict_array_index():
+    """E2: gen_param_dict 处理含数字下标 key，构造预填 None 的 list。"""
+    arg = _build_unfold_arg()
+    out = arg.gen_param_dict({"A.0.B": "v"})
+    assert isinstance(out, list) and len(out) == 1
+    assert out[0]["A"][0]["B"] == "v"
+
+
+def test_E3_gen_param_dict_no_array_two_seg():
+    """E3: gen_param_dict 单层无下标 key 直接挂值。"""
+    arg = _build_unfold_arg()
+    out = arg.gen_param_dict({"A.B": "v"})
+    assert out == [{"A": {"B": "v"}}]
+
+
+def test_E4_internal_gen_param_dict_empty_param():
+    """E4: _gen_param_dict 入参为空时直接返回空 dict。"""
+    arg = _build_unfold_arg()
+    bag = {}
+    out = arg._gen_param_dict([], bag)
+    assert bag == {}
+
+
+def test_E5_internal_gen_param_dict_three_seg_with_index():
+    """E5: _gen_param_dict 处理 3 段含数字下标参数。"""
+    arg = _build_unfold_arg()
+    bag = {}
+    arg._gen_param_dict(["A", "0", "x"], bag)
+    assert bag == {"A": ["x"]}
+
+
+def test_E6_internal_gen_param_dict_three_seg_object():
+    """E6: _gen_param_dict 处理 3 段无下标参数。"""
+    arg = _build_unfold_arg()
+    bag = {}
+    arg._gen_param_dict(["A", "B", "v"], bag)
+    assert bag == {"A": {"B": "v"}}
+
+
+def test_E7_recur_merge_dict_dict_branch():
+    """E7: recur_merge_dict 在两个 dict 上递归合并新 key。"""
+    arg = _build_unfold_arg()
+    src = {"A": {"X": "1"}}
+    dis = {"A": {"Y": "2"}}
+    out = arg.recur_merge_dict(src, dis)
+    assert out == {"A": {"X": "1", "Y": "2"}}
+
+
+def test_E8_recur_merge_dict_list_branch():
+    """E8: recur_merge_dict 在 list 上按下标合并标量 / dict 元素。"""
+    arg = _build_unfold_arg()
+    src = [{"X": "1"}, "scalar2"]
+    dis = [{"Y": "2"}, None]
+    out = arg.recur_merge_dict(src, dis)
+    # list[0] 走 dict 递归，list[1] 走标量赋值
+    assert out[0] == {"X": "1", "Y": "2"}
+    assert out[1] == "scalar2"
+
+
+def test_E9_merge_dict_empty_returns_empty():
+    """E9: merge_dict 空列表返回空 dict。"""
+    arg = _build_unfold_arg()
+    assert arg.merge_dict([]) == {}
+
+
+def test_E10_merge_dict_disjoint_keys():
+    """E10: merge_dict 两个互斥 key 字典合并为一个。"""
+    arg = _build_unfold_arg()
+    out = arg.merge_dict([{"A": "1"}, {"B": "2"}])
+    assert out == {"A": "1", "B": "2"}
+
+
+def test_E11_merge_dict_overlapping_keys_recurse():
+    """E11: merge_dict 重叠 key 递归合并子结构。"""
+    arg = _build_unfold_arg()
+    out = arg.merge_dict([
+        {"A": {"X": "1"}},
+        {"A": {"Y": "2"}},
+    ])
+    assert out == {"A": {"X": "1", "Y": "2"}}
+
+
+def test_E12_build_action_parameters_old_simple():
+    """E12: build_action_parameters_old 旧路径——单层无下标 key。"""
+    arg = _build_unfold_arg()
+    ns = _ns(**{"A.B": "v"})
+    out = arg.build_action_parameters_old(ns)
+    assert out == {"A": {"B": "v"}}
+
+
+def test_E13_build_action_parameters_old_with_array():
+    """E13: build_action_parameters_old 旧路径——含数字下标 key。"""
+    arg = _build_unfold_arg()
+    ns = _ns(**{"A.0.B": "v1", "A.1.B": "v2"})
+    out = arg.build_action_parameters_old(ns)
+    assert out["A"][0]["B"] == "v1"
+    assert out["A"][1]["B"] == "v2"
+
+
+def test_E14_build_action_parameters_old_skips_none():
+    """E14: build_action_parameters_old 旧路径——value 为 None 的项被跳过。"""
+    arg = _build_unfold_arg()
+    ns = _ns(**{"A.B": "v", "A.C": None})
+    out = arg.build_action_parameters_old(ns)
+    assert out == {"A": {"B": "v"}}

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1187,6 +1187,27 @@ def test_G7_unfold_equals_form_normalization():
         restore()
 
 
+def test_G8_unfold_single_rule_value_preserves_list_type():
+    """截断点以下的 list 字段只有一个值时，请求体仍应保留 list 类型。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+    captured = {}
+    ac = _make_billing_action_command(captured)
+    restore = _patch_credentials()
+    try:
+        g = _make_globals(profile="default", cli_unfold_argument=True)
+        result = ac([
+            "--Id", "1490",
+            "--RuleList.RuleDetail.Children.0.RuleValue", "ESG",
+        ], g)
+
+        assert result == "ok"
+        leaf = _walk_to_leaf(captured["params"], 0)
+        assert leaf["RuleValue"] == ["ESG"]
+    finally:
+        restore()
+
+
 # I. _match_truncated_prefix 最长前缀匹配
 # ============================================================
 def test_I1_match_truncated_prefix_no_match():
@@ -1462,6 +1483,60 @@ def test_P7_extract_valueless_non_matching_key_kept():
     ac._cli_data = _Trunc()
     out = ac._extract_deep_nested_args(["--WhoAmI"], OrderedDict(), [])
     assert out == ["--WhoAmI"]
+
+
+def test_P8_extract_preserves_single_value_list_type_below_truncation():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "Node"}}
+
+        def get_service_model(self, *a, **kw):
+            return {"objects": {
+                "Node": {"members": [
+                    {"name": "Values", "type": "list", "member": "string"},
+                    {"name": "Name", "type": "string", "member": "string"},
+                ]},
+            }}
+
+    ac._cli_data = _Trunc()
+    extra = OrderedDict()
+    out = ac._extract_deep_nested_args([
+        "--Root.0.Values", "only-one",
+        "--Root.0.Name", "node-name",
+    ], extra, [])
+
+    assert out == []
+    assert extra == {
+        "Root.0.Values": ["only-one"],
+        "Root.0.Name": "node-name",
+    }
+
+
+def test_P9_extract_preserves_single_value_list_type_in_equals_form():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "Node"}}
+
+        def get_service_model(self, *a, **kw):
+            return {"objects": {
+                "Node": {"members": [
+                    {"name": "Values", "type": "list", "member": "string"},
+                ]},
+            }}
+
+    ac._cli_data = _Trunc()
+    extra = OrderedDict()
+    out = ac._extract_deep_nested_args(
+        ["--Root.0.Values=only-one"], extra, [])
+
+    assert out == []
+    assert extra == {"Root.0.Values": ["only-one"]}
 
 
 # ============================================================

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -994,24 +994,13 @@ def test_F5_action_caller_is_invoked_in_normal_mode():
 #   * 合法 + 超限混合场景：合法部分仍可被收集，但超限触发的整体抛错优先级更高。
 # ============================================================
 def _build_self_ref_path(num_layers):
-    """基于 billing CreateGatherRule 截断前缀 ``RuleList.RuleDetail.Children.0``
-    构造一段共 ``D`` 段（数字下标段含在内）的扁平参数 key，便于精确控制 depth。
-
-    :param num_layers: 在 4 段截断前缀之外再叠加多少层 ``Children.0``，
-        最后再追加 1 段叶子 ``RuleKey``。
-    :return: ``(key, depth)``，其中 ``depth = 4 + num_layers * 2 + 1``。
-
-    示例：
-      * ``num_layers=0`` → ``RuleList.RuleDetail.Children.0.RuleKey`` (D=5)
-      * ``num_layers=1`` → ``RuleList.RuleDetail.Children.0.Children.0.RuleKey`` (D=7)
-      * ``num_layers=13`` → 30 段 (D=30) —— 边界放行
-      * ``num_layers=14`` → 32 段 (D=32) —— 超限
-    """
+    """构造以 ``RuleKey`` 结尾的自引用路径并返回非数字字段深度。"""
     base = ["RuleList", "RuleDetail", "Children", "0"]
     for _ in range(num_layers):
         base += ["Children", "0"]
     base.append("RuleKey")
-    return ".".join(base), len(base)
+    depth = sum(1 for segment in base if not segment.isdigit())
+    return ".".join(base), depth
 
 
 def _walk_to_leaf(params, num_layers):
@@ -1061,7 +1050,7 @@ def _patch_credentials():
 
 
 def test_G3_unfold_depth_30_passthrough_boundary():
-    """G3: D=30（边界值，严格 ≤ MAX_INPUT_DEPTH）应放行。"""
+    """G3: D=30 的合法字段 key（末段非数组下标）应放行。"""
     if not _billing_schema_available():
         pytest.skip("local billing api.json missing")
     captured = {}
@@ -1069,32 +1058,21 @@ def test_G3_unfold_depth_30_passthrough_boundary():
     restore = _patch_credentials()
     try:
         parts = ["RuleList", "RuleDetail", "Children", "0"]
-        for _ in range(13):
+        for _ in range(26):
             parts += ["Children", "0"]
-        # 4 + 13*2 = 30 段，末段是 "0"
+        parts.append("RuleKey")
         key = ".".join(parts)
-        assert len(parts) == 30
+        depth = sum(1 for seg in parts if not seg.isdigit())
+        assert depth == 30
 
         g = _make_globals(profile="default", cli_unfold_argument=True)
         result = ac([
             "--Id", "1490",
-            "--" + key, "value_d30_pure",
+            "--" + key, "value_d30",
         ], g)
         assert result == "ok"
-        # RuleList 是 dict（schema 中并非 list，只有一个 RuleDetail 字段）。
-        # 沿 RuleList.RuleDetail.Children[0] 进入；之后再连续 12 次 Children[0]；
-        # 第 13 次 Children list 末端 list[0] 即标量值 "value_d30_pure"。
-        cursor = captured["params"]["RuleList"]["RuleDetail"]["Children"]
-        assert isinstance(cursor, list) and len(cursor) == 1
-        cursor = cursor[0]
-        for _ in range(12):
-            cursor = cursor["Children"]
-            assert isinstance(cursor, list) and len(cursor) == 1
-            cursor = cursor[0]
-        # 第 13 次：Children list，末端就是 list[0] 的标量值
-        cursor = cursor["Children"]
-        assert isinstance(cursor, list) and len(cursor) == 1
-        assert cursor[0] == "value_d30_pure"
+        leaf = _walk_to_leaf(captured["params"], 26)
+        assert leaf == {"RuleKey": "value_d30"}
     finally:
         restore()
 
@@ -1173,7 +1151,7 @@ def test_G7_unfold_equals_form_normalization():
     restore = _patch_credentials()
     try:
         key, depth = _build_self_ref_path(0)
-        assert depth == 5
+        assert depth == 4
         g = _make_globals(profile="default", cli_unfold_argument=True)
         # 用 = 形式
         result = ac([
@@ -1208,37 +1186,31 @@ def test_G8_unfold_single_rule_value_preserves_list_type():
         restore()
 
 
-# I. _match_truncated_prefix 最长前缀匹配
+# I. _is_recursive_key 布尔前缀判断
 # ============================================================
-def test_I1_match_truncated_prefix_no_match():
-    prefix, tname = ActionCommand._match_truncated_prefix(
-        "Foo.Bar", OrderedDict([("Root.0", "T")]))
-    assert prefix is None
-    assert tname == ""
+def test_I1_recursive_key_no_match():
+    assert ActionCommand._is_recursive_key(
+        "Foo.Bar", OrderedDict([("Root.0", "T")])) is False
 
 
-def test_I2_match_truncated_prefix_strict_dot_boundary():
+def test_I2_recursive_key_strict_dot_boundary():
     trunc = OrderedDict([("Root.0", "T")])
-    prefix, tname = ActionCommand._match_truncated_prefix("Root.0.Sub", trunc)
-    assert prefix == "Root.0"
-    assert tname == "T"
+    assert ActionCommand._is_recursive_key("Root.0.Sub", trunc) is True
+    assert ActionCommand._is_recursive_key("Root.01.Sub", trunc) is False
 
 
-def test_I3_match_truncated_prefix_longest_wins():
+def test_I3_recursive_key_any_prefix_match_is_enough():
     trunc = OrderedDict([
         ("A.0", "TA"),
         ("A.0.B.0", "TB"),
     ])
-    prefix, tname = ActionCommand._match_truncated_prefix("A.0.B.0.X", trunc)
-    assert prefix == "A.0.B.0"
-    assert tname == "TB"
+    assert ActionCommand._is_recursive_key("A.0.B.0.X", trunc) is True
 
 
-def test_I4_match_truncated_prefix_equal_no_dot_suffix_not_hit():
+def test_I4_recursive_key_equal_prefix_not_hit():
     """key 与前缀完全相等时不算命中（要求 prefix + '.' 严格前缀）。"""
     trunc = OrderedDict([("Root.0", "T")])
-    prefix, tname = ActionCommand._match_truncated_prefix("Root.0", trunc)
-    assert prefix is None
+    assert ActionCommand._is_recursive_key("Root.0", trunc) is False
 
 
 # ============================================================
@@ -1351,26 +1323,20 @@ def test_O1_oversized_hint_empty_returns_empty_str():
 
 def test_O2_oversized_hint_single_entry_full_text():
     ac = _make_action_command()
-    hint = ac._build_oversized_hint([("A.B.C", 31, "A.B", "T")])
+    hint = ac._build_oversized_hint([("A.B.C", 31)])
     assert "MAX_INPUT_DEPTH=30" in hint
     assert "depth=31" in hint
     assert "--A.B.C" in hint
-    assert "under --A.B" in hint
-    assert "type: T" in hint
+    assert "under --" not in hint
+    assert "type:" not in hint
     assert "Use --cli-input-json file://" in hint
 
 
-def test_O3_oversized_hint_missing_type_falls_back_to_unknown():
-    ac = _make_action_command()
-    hint = ac._build_oversized_hint([("A.X", 31, "A", "")])
-    assert "type: unknown" in hint
-
-
-def test_O4_oversized_hint_multiple_entries_each_on_own_line():
+def test_O3_oversized_hint_multiple_entries_each_on_own_line():
     ac = _make_action_command()
     hint = ac._build_oversized_hint([
-        ("A.X", 31, "A", "T1"),
-        ("B.Y", 32, "B", "T2"),
+        ("A.X", 31),
+        ("B.Y", 32),
     ])
     assert "--A.X" in hint
     assert "--B.Y" in hint
@@ -1418,8 +1384,8 @@ def test_P3_extract_no_truncated_returns_original():
     assert out == remaining
 
 
-def test_P4_extract_service_model_raises_still_works():
-    """get_service_model 抛异常不会影响主流程（service_model=None 时仍能收集）。"""
+def test_P4_extract_service_model_raises_keeps_original():
+    """无法查询 schema 时不得猜测字段类型或消费参数。"""
     ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
 
     class _PartLoader(object):
@@ -1432,10 +1398,10 @@ def test_P4_extract_service_model_raises_still_works():
     ac._cli_data = _PartLoader()
     extra = OrderedDict()
     oversized = []
-    out = ac._extract_deep_nested_args(
-        ["--Root.0.Sub", "v"], extra, oversized)
-    assert out == []
-    assert extra == {"Root.0.Sub": "v"}
+    remaining = ["--Root.0.Sub", "v"]
+    out = ac._extract_deep_nested_args(remaining, extra, oversized)
+    assert out == remaining
+    assert extra == OrderedDict()
 
 
 def test_P5_extract_non_dash_token_kept_in_new_remaining():
@@ -1495,6 +1461,9 @@ def test_P8_extract_preserves_single_value_list_type_below_truncation():
 
         def get_service_model(self, *a, **kw):
             return {"objects": {
+                "CreateGatherRuleRequest": {"members": [
+                    {"name": "Root", "type": "list", "member": "Node"},
+                ]},
                 "Node": {"members": [
                     {"name": "Values", "type": "list", "member": "string"},
                     {"name": "Name", "type": "string", "member": "string"},
@@ -1525,6 +1494,9 @@ def test_P9_extract_preserves_single_value_list_type_in_equals_form():
 
         def get_service_model(self, *a, **kw):
             return {"objects": {
+                "CreateGatherRuleRequest": {"members": [
+                    {"name": "Root", "type": "list", "member": "Node"},
+                ]},
                 "Node": {"members": [
                     {"name": "Values", "type": "list", "member": "string"},
                 ]},
@@ -1537,6 +1509,134 @@ def test_P9_extract_preserves_single_value_list_type_in_equals_form():
 
     assert out == []
     assert extra == {"Root.0.Values": ["only-one"]}
+
+
+def test_P10_get_key_type_uses_complete_key_from_request_root():
+    objects = {
+        "Request": {"members": [
+            {"name": "Root", "type": "list", "member": "Node"},
+        ]},
+        "Node": {"members": [
+            {"name": "Children", "type": "list", "member": "Node"},
+            {"name": "Values", "type": "list", "member": "string"},
+            {"name": "Name", "type": "string", "member": "string"},
+        ]},
+    }
+
+    assert ActionCommand._get_key_type(
+        "Root.0.Children.1.Values", "Request", objects) == "list"
+    assert ActionCommand._get_key_type(
+        "Root.0.Children.1.Name", "Request", objects) == "scalar"
+    assert ActionCommand._get_key_type(
+        "Root.Children.0.Name", "Request", objects) is None
+    assert ActionCommand._get_key_type(
+        "Root.0.Missing", "Request", objects) is None
+    assert ActionCommand._get_key_type(
+        "Root.0.Children.0", "Request", objects) is None
+    assert ActionCommand._get_key_type(
+        "Root.0", "Request", objects) is None
+
+
+def test_P11_extract_matched_prefix_with_invalid_field_is_not_consumed():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "Node"}}
+
+        def get_service_model(self, *a, **kw):
+            return {"objects": {
+                "CreateGatherRuleRequest": {"members": [
+                    {"name": "Root", "type": "list", "member": "Node"},
+                ]},
+                "Node": {"members": [
+                    {"name": "Name", "type": "string", "member": "string"},
+                ]},
+            }}
+
+    ac._cli_data = _Trunc()
+    remaining = ["--Root.0.Missing", "value"]
+    extra = OrderedDict()
+    out = ac._extract_deep_nested_args(remaining, extra, [])
+
+    assert out == remaining
+    assert extra == OrderedDict()
+
+
+def test_P12_extract_scalar_with_multiple_values_is_not_consumed():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "Node"}}
+
+        def get_service_model(self, *a, **kw):
+            return {"objects": {
+                "CreateGatherRuleRequest": {"members": [
+                    {"name": "Root", "type": "list", "member": "Node"},
+                ]},
+                "Node": {"members": [
+                    {"name": "Name", "type": "string", "member": "string"},
+                ]},
+            }}
+
+    ac._cli_data = _Trunc()
+    remaining = ["--Root.0.Name", "first", "second"]
+    extra = OrderedDict()
+    out = ac._extract_deep_nested_args(remaining, extra, [])
+
+    assert out == remaining
+    assert extra == OrderedDict()
+
+
+def test_P13_extract_terminal_array_index_is_not_consumed():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "Node"}}
+
+        def get_service_model(self, *a, **kw):
+            return {"objects": {
+                "CreateGatherRuleRequest": {"members": [
+                    {"name": "Root", "type": "list", "member": "Node"},
+                ]},
+                "Node": {"members": [
+                    {"name": "Children", "type": "list", "member": "Node"},
+                ]},
+            }}
+
+    ac._cli_data = _Trunc()
+    remaining = ["--Root.0.Children.0", "value"]
+    extra = OrderedDict()
+    out = ac._extract_deep_nested_args(remaining, extra, [])
+
+    assert out == remaining
+    assert extra == OrderedDict()
+
+
+def test_P14_extract_checks_depth_before_loading_service_model():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "Node"}}
+
+        def get_service_model(self, *a, **kw):
+            raise AssertionError("oversized key must not load service model")
+
+    ac._cli_data = _Trunc()
+    key = "Root.0." + ".".join("Field%d" % i for i in range(30))
+    oversized = []
+    out = ac._extract_deep_nested_args(
+        ["--" + key, "value"], OrderedDict(), oversized)
+
+    assert out == []
+    assert oversized == [(key, 31)]
 
 
 # ============================================================

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -75,13 +75,18 @@ def _run_tccli(args):
         "import tccli.plugin as _p; _p.import_plugins=lambda: {};\n"
         "from tccli.main import main; sys.argv = %r; sys.exit(main())"
     ) % (_REPO_ROOT, ["tccli"] + list(args))
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
     proc = subprocess.Popen(
         [sys.executable, "-c", code],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+        env=env,
     )
-    out, err = proc.communicate(timeout=60)
+    if sys.version_info[0] < 3:
+        out, err = proc.communicate()
+    else:
+        out, err = proc.communicate(timeout=60)
     return proc.returncode, out.decode("utf-8", "replace"), err.decode("utf-8", "replace")
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -14,9 +14,8 @@
 
 设计要点：
   - 现有 subprocess 测试只能验证端到端行为，但 coverage 工具
-    无法统计子进程内的代码执行。所以本文件大量增加“主进程内
-    直接调用类方法”的白盒测试，以提升真实覆盖率。
-"""
+    无法统计子进程内的代码执行。所以本文件大量增加"主进程内
+    直接调用类方法"的白盒测试，以提高真实覆盖率。"""
 import os
 import sys
 import copy
@@ -46,7 +45,7 @@ while _REPO_ROOT in sys.path:
 sys.path.insert(0, _REPO_ROOT)
 
 # ============================================================
-# 通用：屏蔽 plugin 加载（很多 tccli 插件依赖外部 SDK，环境可能没装）
+# 通用：屏蔽 plugin 加载（很多 tccli 插件依赖外部 SDK，环境可能没装好）
 # ============================================================
 import tccli.plugin as _plg
 _plg.import_plugins = lambda: {}
@@ -995,7 +994,7 @@ def test_F5_action_caller_is_invoked_in_normal_mode():
 #   * 合法 + 超限混合场景：合法部分仍可被收集，但超限触发的整体抛错优先级更高。
 # ============================================================
 def _build_self_ref_path(num_layers):
-    """构造以 ``RuleKey`` 结尾的自引用路径并返回非数字字段深度。"""
+    """Construct a self-ref path ending with RuleKey and return non-digit field depth."""
     base = ["RuleList", "RuleDetail", "Children", "0"]
     for _ in range(num_layers):
         base += ["Children", "0"]
@@ -1510,134 +1509,6 @@ def test_P9_extract_preserves_single_value_list_type_in_equals_form():
 
     assert out == []
     assert extra == {"Root.0.Values": ["only-one"]}
-
-
-def test_P10_get_key_type_uses_complete_key_from_request_root():
-    objects = {
-        "Request": {"members": [
-            {"name": "Root", "type": "list", "member": "Node"},
-        ]},
-        "Node": {"members": [
-            {"name": "Children", "type": "list", "member": "Node"},
-            {"name": "Values", "type": "list", "member": "string"},
-            {"name": "Name", "type": "string", "member": "string"},
-        ]},
-    }
-
-    assert ActionCommand._get_key_type(
-        "Root.0.Children.1.Values", "Request", objects) == "list"
-    assert ActionCommand._get_key_type(
-        "Root.0.Children.1.Name", "Request", objects) == "scalar"
-    assert ActionCommand._get_key_type(
-        "Root.Children.0.Name", "Request", objects) is None
-    assert ActionCommand._get_key_type(
-        "Root.0.Missing", "Request", objects) is None
-    assert ActionCommand._get_key_type(
-        "Root.0.Children.0", "Request", objects) is None
-    assert ActionCommand._get_key_type(
-        "Root.0", "Request", objects) is None
-
-
-def test_P11_extract_matched_prefix_with_invalid_field_is_not_consumed():
-    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
-
-    class _Trunc(object):
-        def get_unfold_param_info(self, *a, **kw):
-            return {"Root.0": {"recursive_truncated": True,
-                               "recursive_type": "Node"}}
-
-        def get_service_model(self, *a, **kw):
-            return {"objects": {
-                "CreateGatherRuleRequest": {"members": [
-                    {"name": "Root", "type": "list", "member": "Node"},
-                ]},
-                "Node": {"members": [
-                    {"name": "Name", "type": "string", "member": "string"},
-                ]},
-            }}
-
-    ac._cli_data = _Trunc()
-    remaining = ["--Root.0.Missing", "value"]
-    extra = OrderedDict()
-    out = ac._extract_deep_nested_args(remaining, extra, [])
-
-    assert out == remaining
-    assert extra == OrderedDict()
-
-
-def test_P12_extract_scalar_with_multiple_values_is_not_consumed():
-    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
-
-    class _Trunc(object):
-        def get_unfold_param_info(self, *a, **kw):
-            return {"Root.0": {"recursive_truncated": True,
-                               "recursive_type": "Node"}}
-
-        def get_service_model(self, *a, **kw):
-            return {"objects": {
-                "CreateGatherRuleRequest": {"members": [
-                    {"name": "Root", "type": "list", "member": "Node"},
-                ]},
-                "Node": {"members": [
-                    {"name": "Name", "type": "string", "member": "string"},
-                ]},
-            }}
-
-    ac._cli_data = _Trunc()
-    remaining = ["--Root.0.Name", "first", "second"]
-    extra = OrderedDict()
-    out = ac._extract_deep_nested_args(remaining, extra, [])
-
-    assert out == remaining
-    assert extra == OrderedDict()
-
-
-def test_P13_extract_terminal_array_index_is_not_consumed():
-    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
-
-    class _Trunc(object):
-        def get_unfold_param_info(self, *a, **kw):
-            return {"Root.0": {"recursive_truncated": True,
-                               "recursive_type": "Node"}}
-
-        def get_service_model(self, *a, **kw):
-            return {"objects": {
-                "CreateGatherRuleRequest": {"members": [
-                    {"name": "Root", "type": "list", "member": "Node"},
-                ]},
-                "Node": {"members": [
-                    {"name": "Children", "type": "list", "member": "Node"},
-                ]},
-            }}
-
-    ac._cli_data = _Trunc()
-    remaining = ["--Root.0.Children.0", "value"]
-    extra = OrderedDict()
-    out = ac._extract_deep_nested_args(remaining, extra, [])
-
-    assert out == remaining
-    assert extra == OrderedDict()
-
-
-def test_P14_extract_checks_depth_before_loading_service_model():
-    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
-
-    class _Trunc(object):
-        def get_unfold_param_info(self, *a, **kw):
-            return {"Root.0": {"recursive_truncated": True,
-                               "recursive_type": "Node"}}
-
-        def get_service_model(self, *a, **kw):
-            raise AssertionError("oversized key must not load service model")
-
-    ac._cli_data = _Trunc()
-    key = "Root.0." + ".".join("Field%d" % i for i in range(30))
-    oversized = []
-    out = ac._extract_deep_nested_args(
-        ["--" + key, "value"], OrderedDict(), oversized)
-
-    assert out == []
-    assert oversized == [(key, 31)]
 
 
 # ============================================================

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,1501 @@
+# -*- coding: utf-8 -*-
+"""
+针对 tccli/command.py 的单元测试。
+
+包含：
+  A) 端到端 subprocess 测试（保留自 test_command_recursive_hint.py）
+     —— 验证客户 TAPD 报障场景的真实退出码和 stderr 输出。
+  B) _build_recursive_hint 白盒分支覆盖
+     —— 这是 self-ref 修复的核心函数，分支较多。
+  C) ActionCommand 内部方法（init / property / 私有助手）
+  D) CLICommand 内部方法
+  E) ServiceCommand 内部方法
+  F) 边界 / 异常 / 健壮性补充
+
+设计要点：
+  - 现有 subprocess 测试只能验证端到端行为，但 coverage 工具
+    无法统计子进程内的代码执行。所以本文件大量增加“主进程内
+    直接调用类方法”的白盒测试，以提升真实覆盖率。
+"""
+import os
+import sys
+import copy
+import subprocess
+from collections import OrderedDict, namedtuple
+
+try:
+    import pytest
+    _HAS_PYTEST = True
+except ImportError:
+    _HAS_PYTEST = False
+
+    class _SkipException(Exception):
+        pass
+
+    class _PytestStub(object):
+        @staticmethod
+        def skip(msg):
+            raise _SkipException(msg)
+
+    pytest = _PytestStub()  # type: ignore
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_TESTS_DIR)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# ============================================================
+# 通用：屏蔽 plugin 加载（很多 tccli 插件依赖外部 SDK，环境可能没装）
+# ============================================================
+import tccli.plugin as _plg
+_plg.import_plugins = lambda: {}
+
+import tccli.options_define as Options_define
+from tccli.command import (
+    BaseCommand, CLICommand, ServiceCommand, ActionCommand,
+)
+from tccli.exceptions import UnknownArgumentError
+from tccli.loaders import Loader
+
+
+# ============================================================
+# 通用工具
+# ============================================================
+def _billing_schema_available():
+    """判断本地是否带有 billing v20180709 api.json。"""
+    api_path = os.path.join(
+        Loader().get_services_path(), "billing", "v20180709", "api.json")
+    return os.path.exists(api_path)
+
+
+def _run_tccli(args):
+    """以子进程方式运行 tccli main，返回 (exit_code, stdout, stderr)。"""
+    code = (
+        "import sys; sys.path.insert(0, %r);\n"
+        "import tccli.plugin as _p; _p.import_plugins=lambda: {};\n"
+        "from tccli.main import main; sys.argv = %r; sys.exit(main())"
+    ) % (_REPO_ROOT, ["tccli"] + list(args))
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+    )
+    out, err = proc.communicate(timeout=60)
+    return proc.returncode, out.decode("utf-8", "replace"), err.decode("utf-8", "replace")
+
+
+def _make_action_command(call_mode=None, profile="default"):
+    """构造一个最小的 ActionCommand 实例（不走 __init__ 完整逻辑），
+       用于直接驱动 _build_recursive_hint / _build_action_parameters 等私有方法。
+
+       不调用 super().__init__() 避免触达真实 Loader（已通过 _cli_data 单独注入）。
+    """
+    ac = object.__new__(ActionCommand)
+    ac._service_name = "billing"
+    ac._version = "2018-07-09"
+    ac._action_name = "CreateGatherRule"
+    ac._call_mode = call_mode
+    ac.profile = profile
+    ac._cli_data = Loader()
+    ac._argument_map = None
+    ac._is_self_ref = True
+    return ac
+
+
+def _make_globals(**kw):
+    """模拟 argparse parsed_globals namespace 对象。
+       用 argparse.Namespace 而非 namedtuple，确保 vars() 可访问 __dict__。
+    """
+    import argparse as _argparse
+    base = {
+        Options_define.Profile: kw.pop("profile", None),
+        Options_define.GenerateCliSkeleton.replace("-", "_"):
+            kw.pop("generate_cli_skeleton", None),
+        Options_define.CliInputJson.replace("-", "_"):
+            kw.pop("cli_input_json", None),
+        Options_define.CliUnfoldArgument.replace("-", "_"):
+            kw.pop("cli_unfold_argument", None),
+    }
+    base.update(kw)
+    return _argparse.Namespace(**base)
+
+
+# ============================================================
+# A. 端到端 subprocess 测试（迁移自原 test_command_recursive_hint.py）
+# ============================================================
+def test_A1_customer_original_command_passes_through_no_recursion_error():
+    """A1: 客户 TAPD 单中提供的命令直接执行：
+       不再出现 RecursionError；穿过自引用截断点 ≤30 段时合法放行至云端调用。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    code, stdout, stderr = _run_tccli([
+        "billing", "CreateGatherRule",
+        "--cli-unfold-argument",
+        "--Id", "1490",
+        "--RuleList.RuleDetail.Children.0.RuleValue", "ESG",
+        "--RuleList.RuleDetail.Children.0.Operator", "in",
+    ])
+
+    combined = stdout + stderr
+
+    # 关键回归点 1：不能再出现递归错误
+    assert "maximum recursion depth exceeded" not in combined, (
+        "RecursionError leaked back to user! stderr:\n%s" % stderr)
+    assert "RecursionError" not in combined
+
+    # 关键回归点 2：参数不再被识别为 Unknown，请求体可被构造
+    # 命令实际是否到达云端取决于本机鉴权，但 CLI 层不应再出 Unknown options
+    assert "Unknown options" not in combined, (
+        "self-ref extension param wrongly rejected:\n%s" % combined)
+    # CLI 层不再产出 self-referencing hint（合法放行后没必要）
+    assert "self-referencing type" not in combined, (
+        "self-ref hint should not appear for legal extension:\n%s" % combined)
+
+
+def test_A1b_oversized_depth_emits_hint():
+    """A1b: 非数字段深度超过 MAX_INPUT_DEPTH=30 时，CLI 层应在发起云端调用前抛 oversized 提示并指向 file://。
+
+    单测约束：不真实发请求。用已 mock action_caller 的 ActionCommand 直接驱动，
+    确保深度超限在 CLI 层被拦截（action_caller 不应被调用）。
+    深度定义为非数字段数量：RuleList(1)+RuleDetail(1)+28*Children(28)+RuleKey(1)=31。
+    """
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+    captured = {}
+    ac = _make_billing_action_command(captured)
+    restore = _patch_credentials()
+    try:
+        parts = ["RuleList", "RuleDetail", "Children", "0"]
+        for _ in range(27):
+            parts += ["Children", "0"]
+        parts += ["RuleKey"]
+        deep_key = ".".join(parts)
+        depth = sum(1 for seg in parts if not seg.isdigit())
+        assert depth == 31
+
+        g = _make_globals(profile="default", cli_unfold_argument=True)
+        try:
+            ac(["--Id", "1490", "--" + deep_key, "v"], g)
+            assert False, "expected UnknownArgumentError for oversized depth"
+        except UnknownArgumentError as e:
+            msg = str(e)
+            assert "RecursionError" not in msg
+            assert "MAX_INPUT_DEPTH=30" in msg
+            assert "depth=31" in msg
+            assert "Use --cli-input-json file://" in msg
+        # 超限场景下不应发起云端调用
+        assert "params" not in captured
+    finally:
+        restore()
+
+
+def test_A2_normal_unknown_option_no_self_ref_hint():
+    """A2: 普通错拼参数不应误触发 self-ref hint。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    code, stdout, stderr = _run_tccli([
+        "billing", "CreateGatherRule",
+        "--cli-unfold-argument",
+        "--Id", "1490",
+        "--TotallyUnknownArg", "x",
+    ])
+
+    assert code == 255
+    assert "Unknown options" in stderr
+    # 不应出现 self-referencing hint —— 因为该参数不属于截断 leaf 前缀
+    assert "self-referencing type" not in stderr, (
+        "false-positive self-ref hint:\n%s" % stderr)
+
+
+def test_A3_pass_self_ref_field_as_json_no_hint_about_self_ref():
+    """A3: --generate-cli-skeleton 模式不应触发 unknown options，也不应出现 self-ref hint。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    code, stdout, stderr = _run_tccli([
+        "billing", "CreateGatherRule",
+        "--cli-unfold-argument",
+        "--generate-cli-skeleton",
+    ])
+
+    assert "Unknown options" not in stderr
+    assert "self-referencing type" not in stderr
+
+
+# ============================================================
+# B. _build_recursive_hint 白盒分支覆盖（核心修复点）
+# ============================================================
+def test_B1_hint_returns_empty_when_not_unfold_mode():
+    """B1: 非 --cli-unfold-argument 模式下直接返回空串。"""
+    ac = _make_action_command(call_mode=None)
+    assert ac._build_recursive_hint(["--foo", "bar"]) == ""
+
+    # 显式设为 generate-cli-skeleton 模式也应返回空串
+    ac._call_mode = Options_define.GenerateCliSkeleton
+    assert ac._build_recursive_hint(["--foo"]) == ""
+
+
+def test_B2_hint_returns_empty_when_loader_raises():
+    """B2: Loader.get_unfold_param_info 抛异常时静默返回空串。"""
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _BadLoader(object):
+        def get_unfold_param_info(self, *a, **kw):
+            raise RuntimeError("mock failure")
+    ac._cli_data = _BadLoader()
+    assert ac._build_recursive_hint(["--anything"]) == ""
+
+
+def test_B3_hint_returns_empty_when_no_truncated_leaf():
+    """B3: 当 unfold 清单中没有任何 recursive_truncated 字段时，返回空串。"""
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _NoTrunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {
+                "Foo": {"recursive_truncated": False},
+                "Bar.Baz": {},  # 无 recursive_truncated 键
+            }
+    ac._cli_data = _NoTrunc()
+    assert ac._build_recursive_hint(["--Foo.NotExist", "x"]) == ""
+
+
+def test_B4_hint_returns_empty_when_no_token_matches():
+    """B4: 有截断点但用户的非法参数都不命中前缀 → 返回空串。"""
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {
+                "RuleList.RuleDetail.Children.0": {
+                    "recursive_truncated": True,
+                    "recursive_type": "AllocationRuleExpression",
+                }
+            }
+    ac._cli_data = _Trunc()
+    # remaining 中无任何前缀命中 RuleList.RuleDetail.Children.0
+    assert ac._build_recursive_hint(["--Other.Param", "v"]) == ""
+
+
+def test_B5_hint_emits_full_text_on_match():
+    """B5: 命中截断前缀时，输出包含 self-referencing type 上下文与 file:// 单选项替代方案。
+
+    方案变更（recursive-nesting-30 / 方式 A）：
+      - 移除 (1) Drop --cli-unfold-argument 选项与 applies to 上下文行；
+      - 仅保留 file:// 单一替代方案，配合反向断言锁定不再回退。
+    顶层字段名仍可在每条命中 token 行尾的 (under --RuleList.RuleDetail.Children.0, ...) 中看到。
+    """
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {
+                "RuleList.RuleDetail.Children.0": {
+                    "recursive_truncated": True,
+                    "recursive_type": "AllocationRuleExpression",
+                }
+            }
+    ac._cli_data = _Trunc()
+
+    hint = ac._build_recursive_hint([
+        "--RuleList.RuleDetail.Children.0.RuleKey", "x",
+        "--RuleList.RuleDetail.Children.0.Operator", "in",
+    ])
+    assert "self-referencing type" in hint
+    assert "AllocationRuleExpression" in hint
+    assert "--RuleList.RuleDetail.Children.0" in hint
+    # 单选项 hint：仅保留 file://
+    assert "Use --cli-input-json file://" in hint
+    # 反向断言：旧的 Drop 方案与 applies to 上下文不应再出现
+    assert "Drop --cli-unfold-argument" not in hint
+    assert "applies to:" not in hint
+
+
+def test_B6_hint_falls_back_when_recursive_type_missing():
+    """B6: recursive_type 为空时，提示文案降级显示 'unknown' 占位。"""
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {
+                "X.Y.Z.0": {
+                    "recursive_truncated": True,
+                    "recursive_type": "",  # ← 空字符串
+                }
+            }
+    ac._cli_data = _Trunc()
+    hint = ac._build_recursive_hint(["--X.Y.Z.0.More", "v"])
+    assert "self-referencing type: unknown" in hint
+    # 单选项 hint 始终输出 file:// 替代方案
+    assert "Use --cli-input-json file://" in hint
+    assert "Drop --cli-unfold-argument" not in hint
+
+
+def test_B7_hint_skips_non_string_or_non_option_tokens():
+    """B7: remaining 中非字符串 token、不以 -- 开头的 token 应被忽略。"""
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {
+                "Top.0": {
+                    "recursive_truncated": True,
+                    "recursive_type": "T",
+                }
+            }
+    ac._cli_data = _Trunc()
+    # 包含数字、None、不带 -- 的字符串
+    hint = ac._build_recursive_hint([
+        123, None, "no_dashes", "--Top.0.Sub", "v",
+    ])
+    # 只有 --Top.0.Sub 命中
+    assert "--Top.0.Sub" in hint
+
+
+def test_B8_hint_dedup_top_fields_across_multiple_prefixes():
+    """B8: 多个截断点共享同一顶层字段时 top_fields 不重复。"""
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {
+                "Root.A.0": {"recursive_truncated": True, "recursive_type": "TA"},
+                "Root.B.0": {"recursive_truncated": True, "recursive_type": "TB"},
+            }
+    ac._cli_data = _Trunc()
+    hint = ac._build_recursive_hint([
+        "--Root.A.0.X", "1",
+        "--Root.B.0.Y", "2",
+    ])
+    # 方式 A 已移除 applies to 行；改为断言两条命中 token 行都各自标注顶层 prefix
+    assert "--Root.A.0.X  (under --Root.A.0," in hint
+    assert "--Root.B.0.Y  (under --Root.B.0," in hint
+    assert "applies to:" not in hint
+
+
+def test_B9_hint_collects_multi_top_fields():
+    """B9: 不同顶层字段都命中时，applies to 列出多个。"""
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {
+                "Alpha.0": {"recursive_truncated": True, "recursive_type": "T1"},
+                "Beta.0": {"recursive_truncated": True, "recursive_type": "T2"},
+            }
+    ac._cli_data = _Trunc()
+    hint = ac._build_recursive_hint([
+        "--Alpha.0.x", "1",
+        "--Beta.0.y", "2",
+    ])
+    # 方式 A 已移除 applies to 行；不同顶层字段在各自命中 token 行的尾巴里出现
+    assert "(under --Alpha.0," in hint
+    assert "(under --Beta.0," in hint
+    assert "applies to:" not in hint
+
+
+# ============================================================
+# C. ActionCommand 内部方法
+# ============================================================
+def test_C1_actioncommand_init_basic():
+    """C1: ActionCommand 初始化基本字段。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+    ac = ActionCommand(
+        service_name="billing",
+        version="2018-07-09",
+        action_name="CreateGatherRule",
+        action_model={"input": "CreateGatherRuleRequest", "name": "CreateGatherRule"},
+        action_caller=lambda *a, **kw: None,
+    )
+    assert ac._service_name == "billing"
+    assert ac._version == "2018-07-09"
+    assert ac._action_name == "CreateGatherRule"
+    assert ac._call_mode is None
+    assert ac.profile == "default"
+    assert ac._argument_map is None
+
+
+def test_C2_actioncommand_init_default_version_when_none():
+    """C2: 传入 version=None 时使用 service 默认版本。"""
+    if not os.path.isdir(os.path.join(Loader().get_services_path(), "cvm")):
+        pytest.skip("cvm service missing")
+    ac = ActionCommand(
+        service_name="cvm",
+        version=None,
+        action_name="DescribeInstances",
+        action_model={"input": "DescribeInstancesRequest"},
+        action_caller=lambda *a, **kw: None,
+    )
+    # 至少能拿到一个非空版本号
+    assert ac._version is not None and len(ac._version) > 0
+
+
+def test_C3_get_call_mode_branches():
+    """C3: _get_call_mode 三种模式分支识别。"""
+    ac = _make_action_command()
+
+    # GenerateCliSkeleton
+    g = _make_globals(generate_cli_skeleton=True)
+    assert ac._get_call_mode(g) == Options_define.GenerateCliSkeleton
+
+    # CliInputJson
+    g2 = _make_globals(cli_input_json=True)
+    assert ac._get_call_mode(g2) == Options_define.CliInputJson
+
+    # CliUnfoldArgument
+    g3 = _make_globals(cli_unfold_argument=True)
+    assert ac._get_call_mode(g3) == Options_define.CliUnfoldArgument
+
+    # 全 None → 返回 None（普通模式）
+    g4 = _make_globals()
+    assert ac._get_call_mode(g4) is None
+
+
+def test_C4_get_profile_branches():
+    """C4: _get_profile 在 parsed_globals.profile 有值/无值时分别处理。"""
+    ac = _make_action_command()
+
+    # 有值
+    g = _make_globals(profile="myprof")
+    ac._get_profile(g)
+    assert ac.profile == "myprof"
+
+    # 无值（None / 空）→ 默认 default
+    g2 = _make_globals(profile=None)
+    ac._get_profile(g2)
+    assert ac.profile == "default"
+
+
+def test_C5_get_param_model_unfold_vs_normal():
+    """C5: _get_param_model 在不同 call_mode 下走不同 Loader API。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+    unfold_info = ac._get_param_model()
+    # unfold 模式产物含点号路径 key
+    assert any("." in k for k in unfold_info.keys())
+
+    ac._call_mode = None  # 普通模式
+    normal_info = ac._get_param_model()
+    # 普通模式 key 是顶层字段名
+    assert "Id" in normal_info
+    # 顶层 key 不应该含 "."
+    assert all("." not in k for k in normal_info.keys())
+
+
+def test_C6_build_parameter_map_skeleton_and_input_json_modes():
+    """C6: _build_parameter_map 在 GenerateCliSkeleton / CliInputJson 模式下返回空 map。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    ac = _make_action_command(call_mode=Options_define.GenerateCliSkeleton)
+    ac._action_model = {"input": "CreateGatherRuleRequest"}
+    assert ac._build_parameter_map() == OrderedDict()
+
+    ac._call_mode = Options_define.CliInputJson
+    assert ac._build_parameter_map() == OrderedDict()
+
+
+def test_C7_build_parameter_map_unfold_mode_produces_args():
+    """C7: --cli-unfold-argument 模式下注册多个扁平 option（含点号路径）。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+    ac._action_model = {"input": "CreateGatherRuleRequest"}
+    arg_map = ac._build_parameter_map()
+    assert isinstance(arg_map, OrderedDict)
+    assert "Id" in arg_map  # 简单字段
+    # 点号路径 key 出现
+    assert any("." in k for k in arg_map.keys())
+
+
+def test_C8_build_parameter_map_normal_mode():
+    """C8: 普通模式下注册顶层字段为 option。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    ac = _make_action_command(call_mode=None)  # 普通模式
+    ac._action_model = {"input": "CreateGatherRuleRequest"}
+    arg_map = ac._build_parameter_map()
+    assert "Id" in arg_map
+    assert "RuleList" in arg_map
+    # 不应有 RuleList.RuleDetail.RuleKey 这种点号 key
+    assert not any("." in k for k in arg_map.keys())
+
+
+def test_C9_argument_map_lazy_property():
+    """C9: argument_map 懒加载属性，重复访问返回同一对象。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    ac = _make_action_command(call_mode=None)
+    ac._action_model = {"input": "CreateGatherRuleRequest"}
+    am1 = ac.argument_map
+    am2 = ac.argument_map
+    # 同对象（懒加载缓存）
+    assert am1 is am2
+
+
+def test_C10_create_help_command_returns_action_help():
+    """C10: create_help_command 返回 ActionHelpCommand 实例。"""
+    from tccli.help_command import ActionHelpCommand
+    ac = _make_action_command()
+    hc = ac.create_help_command()
+    assert isinstance(hc, ActionHelpCommand)
+
+
+def test_C11_create_action_parser_returns_argparser():
+    """C11: _create_action_parser 返回 ArgMapArgParser 实例。"""
+    from tccli.argparser import ArgMapArgParser
+    ac = _make_action_command()
+    parser = ac._create_action_parser(OrderedDict())
+    assert isinstance(parser, ArgMapArgParser)
+
+
+def test_C12_build_action_parameters_collects_args():
+    """C12: _build_action_parameters 把 parsed_args 中的字段写入 dict。"""
+    import argparse as _argparse
+    ac = _make_action_command()
+
+    # mock 一个 argument_object
+    class _Arg(object):
+        def __init__(self, name):
+            self.name = name
+
+        def add_to_params(self, params, value):
+            params[self.name] = value
+
+    arg_map = OrderedDict()
+    arg_map["Foo"] = _Arg("Foo")
+    arg_map["Bar"] = _Arg("Bar")
+
+    parsed = _argparse.Namespace(Foo="v1", Bar="v2")
+    out = ac._build_action_parameters(parsed, arg_map)
+    assert out == {"Foo": "v1", "Bar": "v2"}
+
+
+# ============================================================
+# D. CLICommand 内部方法
+# ============================================================
+def test_D1_clicommand_init():
+    """D1: CLICommand 初始化基础字段。"""
+    cli = CLICommand()
+    assert cli._command_map is None
+    assert cli._argument_map is None
+    assert isinstance(cli._cli_data, Loader)
+
+
+def test_D2_get_cli_options_returns_dict():
+    """D2: _get_cli_options 返回 cli 全局 option 字典。"""
+    cli = CLICommand()
+    opts = cli._get_cli_options()
+    assert "secretId" in opts
+    assert "profile" in opts
+
+
+def test_D3_create_cli_argument_returns_custom_argument():
+    """D3: _create_cli_argument 把 option_params 转成 CustomArgument。"""
+    from tccli.argument import CustomArgument
+    cli = CLICommand()
+    arg = cli._create_cli_argument("foo", {"help": "h"})
+    assert isinstance(arg, CustomArgument)
+
+
+def test_D4_build_argument_map_contains_globals():
+    """D4: _build_argument_map 含所有 cli 全局选项。"""
+    cli = CLICommand()
+    am = cli._build_argument_map()
+    assert "secretId" in am
+    assert "profile" in am
+
+
+def test_D5_get_argument_map_lazy():
+    """D5: _get_argument_map 懒加载缓存。"""
+    cli = CLICommand()
+    am1 = cli._get_argument_map()
+    am2 = cli._get_argument_map()
+    assert am1 is am2
+
+
+def test_D6_get_command_map_lazy_and_contains_configure():
+    """D6: _get_command_map 懒加载 + 必含 configure 命令。"""
+    cli = CLICommand()
+    cmap = cli._get_command_map()
+    assert "configure" in cmap
+
+
+def test_D7_get_available_services_returns_iterable():
+    """D7: _get_available_services 返回可迭代对象。"""
+    cli = CLICommand()
+    services = cli._get_available_services()
+    # services 是 dict_keys 或 list
+    assert hasattr(services, "__iter__")
+
+
+def test_D8_get_service_version_no_version_in_argv():
+    """D8: 无 --version 时 _get_service_version 返回 (None, None)。"""
+    cli = CLICommand()
+    saved = sys.argv
+    sys.argv = ["tccli", "billing", "DescribeAccount"]
+    try:
+        s, v = cli._get_service_version()
+        assert s is None and v is None
+    finally:
+        sys.argv = saved
+
+
+def test_D9_get_service_version_with_invalid_version():
+    """D9: --version 后跟非法版本时返回 (None, None)。"""
+    cli = CLICommand()
+    saved = sys.argv
+    sys.argv = ["tccli", "billing", "--version", "not-a-version"]
+    try:
+        s, v = cli._get_service_version()
+        assert s is None and v is None
+    finally:
+        sys.argv = saved
+
+
+def test_D10_get_service_version_with_valid_version():
+    """D10: --version 后跟合法版本时返回 (service, version)。"""
+    cli = CLICommand()
+    saved = sys.argv
+    sys.argv = ["tccli", "billing", "--version", "2018-07-09"]
+    try:
+        s, v = cli._get_service_version()
+        assert s == "billing" and v == "2018-07-09"
+    finally:
+        sys.argv = saved
+
+
+def test_D11_handle_warning_no_crash():
+    """D11: _handle_warning 在常规参数下不抛异常。"""
+    cli = CLICommand()
+    # 不带 --warning，且无 ~/.tccli/default.configure 时也应不崩
+    cli._handle_warning(["billing", "DescribeAccount"])
+    # 带 --warning
+    cli._handle_warning(["billing", "DescribeAccount", "--warning", "on"])
+    # 带 --profile
+    cli._handle_warning(["billing", "DescribeAccount", "--profile", "myp"])
+
+
+def test_D12_handle_service_version_argument_with_version_in_args():
+    """D12: 含 --version + 合法版本时 parser 不重复添加 --version。"""
+    import argparse
+    cli = CLICommand()
+    parser = argparse.ArgumentParser(add_help=False)
+    args = ["billing", "--version", "2018-07-09"]
+    # 不应抛异常
+    cli._handle_service_version_argumnet(args, parser)
+
+
+def test_D13_handle_service_version_argument_without_version():
+    """D13: 不含 --version 时 parser 添加 --version。"""
+    import argparse
+    cli = CLICommand()
+    parser = argparse.ArgumentParser(add_help=False)
+    cli._handle_service_version_argumnet(["billing"], parser)
+    # parser 应该现在有 --version
+    has_version = any(
+        "--version" in (a.option_strings if hasattr(a, "option_strings") else [])
+        for a in parser._actions
+    )
+    assert has_version
+
+
+def test_D14_create_parser_returns_cliarg_parser():
+    """D14: _create_parser 返回 CLIArgParser 实例。"""
+    from tccli.argparser import CLIArgParser
+    cli = CLICommand()
+    cmap = cli._get_command_map()
+    parser = cli._create_parser(cmap)
+    assert isinstance(parser, CLIArgParser)
+    # help 命令被注入
+    assert "help" in cmap
+
+
+def test_D15_clicommand_call_with_as_alias():
+    """D15: __call__ 时第一个参数是 'as' → 替换为 'autoscaling'（如果该 service 存在）。"""
+    cli = CLICommand()
+    avail = cli._cli_data.get_available_services()
+    if "autoscaling" not in avail:
+        pytest.skip("autoscaling service not available")
+    # 模拟 args=["as", "help"]
+    args = ["as", "help"]
+    try:
+        cli(args)
+    except SystemExit:
+        # help 命令通常以 SystemExit 收尾
+        pass
+    except Exception:
+        # 其他异常也允许 —— 我们只验证 'as' 被改写为 'autoscaling'
+        pass
+    # 验证副作用：args[0] 已被替换
+    assert args[0] == "autoscaling"
+
+
+# ============================================================
+# E. ServiceCommand 内部方法
+# ============================================================
+def test_E1_servicecommand_init_default_version():
+    """E1: ServiceCommand 不传 version 使用默认版本。"""
+    if not os.path.isdir(os.path.join(Loader().get_services_path(), "cvm")):
+        pytest.skip("cvm service missing")
+    sc = ServiceCommand("cvm")
+    assert sc._service_name == "cvm"
+    assert sc._version is not None
+
+
+def test_E2_servicecommand_invalid_version_raises():
+    """E2: 传入不存在的版本号抛异常。"""
+    if not os.path.isdir(os.path.join(Loader().get_services_path(), "cvm")):
+        pytest.skip("cvm service missing")
+    try:
+        ServiceCommand("cvm", version="9999-01-01")
+        assert False, "expected exception"
+    except Exception as e:
+        assert "is invalid" in str(e)
+
+
+def test_E3_servicecommand_get_service_model():
+    """E3: _get_service_model 返回 service model dict。"""
+    if not os.path.isdir(os.path.join(Loader().get_services_path(), "cvm")):
+        pytest.skip("cvm service missing")
+    sc = ServiceCommand("cvm")
+    model = sc._get_service_model()
+    assert "actions" in model
+    assert "objects" in model
+
+
+def _make_service_command_in_memory():
+    """构造一个不触碰真实 SDK / 磁盘的 ServiceCommand。
+
+    注入内存 service_model（含 1 个自引用 action + 1 个普通 action），
+    并 mock Services.action_caller，避免 import 真实 tencentcloud SDK 模块。
+    """
+    sc = object.__new__(ServiceCommand)
+    sc._service_name = "svc"
+    sc._version = "2020-01-01"
+    sc._command_map = None
+    sc._cli_data = Loader()
+    service_model = {
+        "metadata": {}, "actions": {
+            "Tree": {"input": "TreeRequest", "name": "Tree"},
+            "Flat": {"input": "FlatRequest", "name": "Flat"},
+        },
+        "objects": {
+            "TreeRequest": {"members": [
+                {"name": "Root", "type": "object", "member": "Node",
+                 "document": "", "required": True}]},
+            "FlatRequest": {"members": [
+                {"name": "Id", "type": "string", "member": "string",
+                 "document": "", "required": True}]},
+            "Node": {"members": [
+                {"name": "Self", "type": "object", "member": "Node",
+                 "document": "", "required": False}]},
+        },
+    }
+    sc._get_service_model = lambda: service_model
+    return sc
+
+
+def test_E4_servicecommand_get_command_map_lazy():
+    """E4: _get_command_map 懒加载，并为自引用 action 注入 _is_self_ref 标记。"""
+    import tccli.services as _Services
+    saved = _Services.action_caller
+    _Services.action_caller = lambda service: (lambda: {
+        "Tree": (lambda *a, **kw: None), "Flat": (lambda *a, **kw: None)})
+    try:
+        sc = _make_service_command_in_memory()
+        cmap1 = sc._get_command_map()
+        cmap2 = sc._get_command_map()
+        assert cmap1 is cmap2  # 懒加载：同一对象
+        assert set(cmap1.keys()) == {"Tree", "Flat"}
+        # 本次改动：自引用 action 被打标，普通 action 不打标
+        assert cmap1["Tree"]._is_self_ref is True
+        assert cmap1["Flat"]._is_self_ref is False
+    finally:
+        _Services.action_caller = saved
+
+
+def test_E5_servicecommand_create_parser_returns_action_parser():
+    """E5: _create_parser 返回 ActionArgParser 实例 + 注入 help。"""
+    from tccli.argparser import ActionArgParser
+    import tccli.services as _Services
+    saved = _Services.action_caller
+    _Services.action_caller = lambda service: (lambda: {
+        "Tree": (lambda *a, **kw: None), "Flat": (lambda *a, **kw: None)})
+    try:
+        sc = _make_service_command_in_memory()
+        cmap = sc._get_command_map()
+        parser = sc._create_parser(cmap)
+        assert isinstance(parser, ActionArgParser)
+        assert "help" in cmap
+    finally:
+        _Services.action_caller = saved
+
+
+def test_E6_servicecommand_create_help_command():
+    """E6: create_help_command 返回 ServiceHelpCommand 实例。"""
+    from tccli.help_command import ServiceHelpCommand
+    if not os.path.isdir(os.path.join(Loader().get_services_path(), "cvm")):
+        pytest.skip("cvm service missing")
+    sc = ServiceCommand("cvm")
+    hc = sc.create_help_command()
+    assert isinstance(hc, ServiceHelpCommand)
+
+
+# ============================================================
+# F. 边界 / 异常 / 健壮性补充
+# ============================================================
+def test_F1_basecommand_loader_inited():
+    """F1: BaseCommand 子类正确继承 _cli_data 字段。"""
+    bc = BaseCommand()
+    assert isinstance(bc._cli_data, Loader)
+
+
+def test_F2_actioncommand_call_unknown_args_raises():
+    """F2: ActionCommand.__call__ 对真正未知参数（拼写错误等）抛 UnknownArgumentError。
+
+       方案变更（recursive-nesting-30）：
+         - 原断言"深入自引用截断点 = 非法"已不再成立——D≤30 的延伸属于合法输入；
+         - 本用例保留"真正的非法参数（拼写错误 / 不命中任何已知前缀）"的负向断言，
+           这条路径与新方案的 ``_extract_deep_nested_args`` 兜底分支严格对齐
+           （需求 1.3：未命中前缀的 token 仍走 Unknown options）。
+    """
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    ac = ActionCommand(
+        service_name="billing",
+        version="2018-07-09",
+        action_name="CreateGatherRule",
+        action_model={"input": "CreateGatherRuleRequest", "name": "CreateGatherRule"},
+        action_caller=lambda *a, **kw: None,
+    )
+    g = _make_globals(cli_unfold_argument=True)
+    try:
+        ac([
+            "--Id", "1490",
+            "--TotallyMadeUpField.NotInSchema", "x",  # 真正的非法参数：不命中任何已知前缀
+        ], g)
+        assert False, "expected UnknownArgumentError"
+    except UnknownArgumentError as e:
+        msg = str(e)
+        assert "Unknown options" in msg
+        assert "--TotallyMadeUpField.NotInSchema" in msg
+        # 反向断言：旧方案的 Drop --cli-unfold-argument 文案不应再出现
+        assert "Drop --cli-unfold-argument" not in msg
+
+
+def test_F3_actioncommand_call_generate_cli_skeleton_short_circuit():
+    """F3: --generate-cli-skeleton 模式不解析参数、不发请求，直接生成模板。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    ac = ActionCommand(
+        service_name="billing",
+        version="2018-07-09",
+        action_name="CreateGatherRule",
+        action_model={"input": "CreateGatherRuleRequest", "name": "CreateGatherRule"},
+        action_caller=lambda *a, **kw: None,
+    )
+    g = _make_globals(generate_cli_skeleton=True)
+
+    # 这个调用通过 generate_skeleton 完成，最常见地是写到 stdout 后返回
+    # 我们不关心内部细节 —— 只要不抛 UnknownArgumentError
+    try:
+        ac([], g)
+    except UnknownArgumentError:
+        assert False, "should not raise UnknownArgumentError in skeleton mode"
+    except SystemExit:
+        # generate_skeleton 内部可能 sys.exit
+        pass
+    except Exception:
+        # 其他异常也允许 —— 例如打印 / IO 失败 —— 重点是 UnknownArgumentError 不发生
+        pass
+
+
+def test_F4_actioncommand_call_help_subcommand():
+    """F4: 第一个位置参数是 'help' 时走 help command 分支。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    ac = ActionCommand(
+        service_name="billing",
+        version="2018-07-09",
+        action_name="CreateGatherRule",
+        action_model={"input": "CreateGatherRuleRequest", "name": "CreateGatherRule"},
+        action_caller=lambda *a, **kw: None,
+    )
+    g = _make_globals()
+    try:
+        ac(["help"], g)
+    except SystemExit:
+        pass
+    except Exception:
+        # help_command(...) 可能依赖外部资源；忽略
+        pass
+
+
+def test_F5_action_caller_is_invoked_in_normal_mode():
+    """F5: 普通模式下，参数合法时调用 action_caller 并传入 action_parameters。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+
+    captured = {}
+
+    def fake_caller(action_parameters, parsed_globals):
+        captured["params"] = action_parameters
+        captured["globals"] = parsed_globals
+        return "ok"
+
+    ac = ActionCommand(
+        service_name="billing",
+        version="2018-07-09",
+        action_name="CreateGatherRule",
+        action_model={"input": "CreateGatherRuleRequest", "name": "CreateGatherRule"},
+        action_caller=fake_caller,
+    )
+    # 以 cli_unfold_argument 模式 + 合法参数避免触达 credentials.maybe_refresh_credential
+    # 但这个分支会调用 credentials —— 用 monkey patch 屏蔽
+    from tccli import credentials
+    saved = credentials.maybe_refresh_credential
+    credentials.maybe_refresh_credential = lambda *a, **kw: None
+    try:
+        g = _make_globals(profile="default", cli_unfold_argument=True)
+        result = ac([
+            "--Id", "1490",
+            "--RuleList.RuleDetail.RuleKey", "tag",
+        ], g)
+        assert result == "ok"
+        assert captured["params"]["Id"] == 1490
+        # cli-unfold-argument 模式下嵌套结构被还原
+        assert captured["params"]["RuleList"]["RuleDetail"]["RuleKey"] == "tag"
+    finally:
+        credentials.maybe_refresh_credential = saved
+
+
+# ============================================================
+# G. recursive-nesting-30 端到端 mock 用例
+# ------------------------------------------------------------
+# 覆盖以下路径：
+#   * 用户输入 D ≤ 30 的合法深嵌套延伸 → 走 _extract_deep_nested_args 兜底分支 →
+#     extra_unfold_args 注入 → build_action_parameters → action_caller 收到完整请求体。
+#   * 用户输入 D > 30 的超限延伸 → 不进 extra_unfold_args，oversized_tokens 触发
+#     UnknownArgumentError，文案含 depth= 与 file:// 替代方案，且不出现旧的 Drop 文案。
+#   * 拼写错误（不命中任何截断前缀）依然抛 Unknown options（与需求 1.3 对齐）。
+#   * 合法 + 超限混合场景：合法部分仍可被收集，但超限触发的整体抛错优先级更高。
+# ============================================================
+def _build_self_ref_path(num_layers):
+    """基于 billing CreateGatherRule 截断前缀 ``RuleList.RuleDetail.Children.0``
+    构造一段共 ``D`` 段（数字下标段含在内）的扁平参数 key，便于精确控制 depth。
+
+    :param num_layers: 在 4 段截断前缀之外再叠加多少层 ``Children.0``，
+        最后再追加 1 段叶子 ``RuleKey``。
+    :return: ``(key, depth)``，其中 ``depth = 4 + num_layers * 2 + 1``。
+
+    示例：
+      * ``num_layers=0`` → ``RuleList.RuleDetail.Children.0.RuleKey`` (D=5)
+      * ``num_layers=1`` → ``RuleList.RuleDetail.Children.0.Children.0.RuleKey`` (D=7)
+      * ``num_layers=13`` → 30 段 (D=30) —— 边界放行
+      * ``num_layers=14`` → 32 段 (D=32) —— 超限
+    """
+    base = ["RuleList", "RuleDetail", "Children", "0"]
+    for _ in range(num_layers):
+        base += ["Children", "0"]
+    base.append("RuleKey")
+    return ".".join(base), len(base)
+
+
+def _walk_to_leaf(params, num_layers):
+    """沿 ``params`` 进入 ``num_layers`` 层 ``Children``（list 取下标 0），最终返回叶子 dict。
+
+    注意 billing CreateGatherRule schema 的真实形态：
+      * ``RuleList`` 是 dict（不是 list！只有一个 RuleDetail 字段）；
+      * ``Children`` 是 list（自引用 leaf 的承载）。
+    本断言基于真实 unfold 注册结果（``RuleList.RuleDetail.RuleKey`` 形态）。
+    """
+    cursor = params["RuleList"]["RuleDetail"]
+    # 第一层 Children
+    cursor = cursor["Children"]
+    assert isinstance(cursor, list) and len(cursor) == 1
+    cursor = cursor[0]
+    # 后续 num_layers 层
+    for _ in range(num_layers):
+        cursor = cursor["Children"]
+        assert isinstance(cursor, list) and len(cursor) == 1
+        cursor = cursor[0]
+    return cursor
+
+
+def _make_billing_action_command(captured):
+    """构造一个 billing CreateGatherRule 的 ActionCommand，绑定捕获 params 的 fake_caller。"""
+    def _caller(action_parameters, parsed_globals):
+        captured["params"] = action_parameters
+        captured["globals"] = parsed_globals
+        return "ok"
+    ac = ActionCommand(
+        service_name="billing",
+        version="2018-07-09",
+        action_name="CreateGatherRule",
+        action_model={"input": "CreateGatherRuleRequest", "name": "CreateGatherRule"},
+        action_caller=_caller,
+    )
+    ac._is_self_ref = True
+    return ac
+
+
+def _patch_credentials():
+    """屏蔽 credentials.maybe_refresh_credential 副作用，返回 (restore_fn)。"""
+    from tccli import credentials
+    saved = credentials.maybe_refresh_credential
+    credentials.maybe_refresh_credential = lambda *a, **kw: None
+    return lambda: setattr(credentials, "maybe_refresh_credential", saved)
+
+
+def test_G3_unfold_depth_30_passthrough_boundary():
+    """G3: D=30（边界值，严格 ≤ MAX_INPUT_DEPTH）应放行。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+    captured = {}
+    ac = _make_billing_action_command(captured)
+    restore = _patch_credentials()
+    try:
+        parts = ["RuleList", "RuleDetail", "Children", "0"]
+        for _ in range(13):
+            parts += ["Children", "0"]
+        # 4 + 13*2 = 30 段，末段是 "0"
+        key = ".".join(parts)
+        assert len(parts) == 30
+
+        g = _make_globals(profile="default", cli_unfold_argument=True)
+        result = ac([
+            "--Id", "1490",
+            "--" + key, "value_d30_pure",
+        ], g)
+        assert result == "ok"
+        # RuleList 是 dict（schema 中并非 list，只有一个 RuleDetail 字段）。
+        # 沿 RuleList.RuleDetail.Children[0] 进入；之后再连续 12 次 Children[0]；
+        # 第 13 次 Children list 末端 list[0] 即标量值 "value_d30_pure"。
+        cursor = captured["params"]["RuleList"]["RuleDetail"]["Children"]
+        assert isinstance(cursor, list) and len(cursor) == 1
+        cursor = cursor[0]
+        for _ in range(12):
+            cursor = cursor["Children"]
+            assert isinstance(cursor, list) and len(cursor) == 1
+            cursor = cursor[0]
+        # 第 13 次：Children list，末端就是 list[0] 的标量值
+        cursor = cursor["Children"]
+        assert isinstance(cursor, list) and len(cursor) == 1
+        assert cursor[0] == "value_d30_pure"
+    finally:
+        restore()
+
+
+def test_G4_unfold_depth_31_rejected():
+    """G4: 非数字段深度 >MAX_INPUT_DEPTH=30 时应抛 UnknownArgumentError，含 depth= 与 file:// 文案。
+
+    注：深度定义为 key 中的\"非数字段\"数量（数组下标 0/1/... 不计入嵌套深度）。
+    构造：RuleList(1) + RuleDetail(1) + 28*Children(28) + RuleKey(1) = 31 个非数字段。
+    """
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+    captured = {}
+    ac = _make_billing_action_command(captured)
+    restore = _patch_credentials()
+    try:
+        parts = ["RuleList", "RuleDetail", "Children", "0"]
+        for _ in range(27):
+            parts += ["Children", "0"]
+        parts += ["RuleKey"]
+        key = ".".join(parts)
+        # 非数字段深度 = 31 > 30
+        depth = sum(1 for seg in parts if not seg.isdigit())
+        assert depth == 31
+
+        g = _make_globals(profile="default", cli_unfold_argument=True)
+        try:
+            ac(["--Id", "1490", "--" + key, "value_d31"], g)
+            assert False, "expected UnknownArgumentError for depth=31"
+        except UnknownArgumentError as e:
+            msg = str(e)
+            assert "depth=31" in msg
+            assert "MAX_INPUT_DEPTH=30" in msg
+            assert "Use --cli-input-json file://" in msg
+            # 反向断言：旧文案不应再出现
+            assert "Drop --cli-unfold-argument" not in msg
+        # 超限场景下 action_caller 不应被调用
+        assert "params" not in captured
+    finally:
+        restore()
+
+
+def test_G5_unfold_typo_unknown_param_still_raises():
+    """G5: 拼写错误（不命中任何已知截断前缀）仍按既有路径抛 Unknown options（需求 1.3）。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+    captured = {}
+    ac = _make_billing_action_command(captured)
+    restore = _patch_credentials()
+    try:
+        g = _make_globals(profile="default", cli_unfold_argument=True)
+        try:
+            ac([
+                "--Id", "1490",
+                "--RuleExpressio.Foo", "x",  # ← RuleExpression 拼写错误
+            ], g)
+            assert False, "expected UnknownArgumentError for typo"
+        except UnknownArgumentError as e:
+            msg = str(e)
+            assert "Unknown options" in msg
+            assert "--RuleExpressio.Foo" in msg
+            # 既不应被识别为深嵌套延伸（不应有 depth= 文案），也不应有旧的 Drop 文案
+            assert "depth=" not in msg
+            assert "Drop --cli-unfold-argument" not in msg
+        assert "params" not in captured
+    finally:
+        restore()
+
+
+def test_G7_unfold_equals_form_normalization():
+    """G7: ``--key=value`` 与 ``--key value`` 两种 argparse 写法等价。"""
+    if not _billing_schema_available():
+        pytest.skip("local billing api.json missing")
+    captured = {}
+    ac = _make_billing_action_command(captured)
+    restore = _patch_credentials()
+    try:
+        key, depth = _build_self_ref_path(0)
+        assert depth == 5
+        g = _make_globals(profile="default", cli_unfold_argument=True)
+        # 用 = 形式
+        result = ac([
+            "--Id", "1490",
+            "--%s=value_eq" % key,
+        ], g)
+        assert result == "ok"
+        leaf = _walk_to_leaf(captured["params"], 0)
+        assert leaf == {"RuleKey": "value_eq"}
+    finally:
+        restore()
+
+
+# I. _match_truncated_prefix 最长前缀匹配
+# ============================================================
+def test_I1_match_truncated_prefix_no_match():
+    prefix, tname = ActionCommand._match_truncated_prefix(
+        "Foo.Bar", OrderedDict([("Root.0", "T")]))
+    assert prefix is None
+    assert tname == ""
+
+
+def test_I2_match_truncated_prefix_strict_dot_boundary():
+    trunc = OrderedDict([("Root.0", "T")])
+    prefix, tname = ActionCommand._match_truncated_prefix("Root.0.Sub", trunc)
+    assert prefix == "Root.0"
+    assert tname == "T"
+
+
+def test_I3_match_truncated_prefix_longest_wins():
+    trunc = OrderedDict([
+        ("A.0", "TA"),
+        ("A.0.B.0", "TB"),
+    ])
+    prefix, tname = ActionCommand._match_truncated_prefix("A.0.B.0.X", trunc)
+    assert prefix == "A.0.B.0"
+    assert tname == "TB"
+
+
+def test_I4_match_truncated_prefix_equal_no_dot_suffix_not_hit():
+    """key 与前缀完全相等时不算命中（要求 prefix + '.' 严格前缀）。"""
+    trunc = OrderedDict([("Root.0", "T")])
+    prefix, tname = ActionCommand._match_truncated_prefix("Root.0", trunc)
+    assert prefix is None
+
+
+# ============================================================
+# J. _collect_truncated_prefixes 静态方法
+# ============================================================
+def test_J1_collect_truncated_prefixes_empty():
+    assert ActionCommand._collect_truncated_prefixes(None) == OrderedDict()
+    assert ActionCommand._collect_truncated_prefixes({}) == OrderedDict()
+
+
+def test_J2_collect_truncated_prefixes_filters_non_truncated():
+    unfold = OrderedDict([
+        ("A.0", {"recursive_truncated": True, "recursive_type": "TA"}),
+        ("B.0", {"recursive_truncated": False, "recursive_type": "TB"}),
+        ("C.0", {}),
+    ])
+    out = ActionCommand._collect_truncated_prefixes(unfold)
+    assert list(out.keys()) == ["A.0"]
+    assert out["A.0"] == "TA"
+
+
+def test_J3_collect_truncated_prefixes_missing_type_becomes_empty():
+    unfold = {"X.0": {"recursive_truncated": True}}
+    out = ActionCommand._collect_truncated_prefixes(unfold)
+    assert out["X.0"] == ""
+
+
+def test_J4_collect_truncated_prefixes_preserves_order():
+    unfold = OrderedDict([
+        ("Z.0", {"recursive_truncated": True, "recursive_type": "TZ"}),
+        ("A.0", {"recursive_truncated": True, "recursive_type": "TA"}),
+        ("M.0", {"recursive_truncated": True, "recursive_type": "TM"}),
+    ])
+    out = ActionCommand._collect_truncated_prefixes(unfold)
+    assert list(out.keys()) == ["Z.0", "A.0", "M.0"]
+
+
+# N. _prefilter_orphan_keys 静态方法
+# ============================================================
+class _FakeAction(object):
+    def __init__(self, option_strings, nargs=None):
+        self.option_strings = option_strings
+        self.nargs = nargs
+
+
+class _FakeParser(object):
+    def __init__(self, actions):
+        self._actions = actions
+
+
+def test_N1_prefilter_orphan_keys_empty_args_no_raise():
+    ActionCommand._prefilter_orphan_keys([], _FakeParser([]))
+
+
+def test_N2_prefilter_equals_form_not_orphan():
+    parser = _FakeParser([_FakeAction(["--k"], nargs=None)])
+    ActionCommand._prefilter_orphan_keys(["--k=v"], parser)
+
+
+def test_N3_prefilter_valueless_option_not_orphan():
+    """nargs==0 的 flag 型 option 允许无值。"""
+    parser = _FakeParser([_FakeAction(["--flag"], nargs=0)])
+    ActionCommand._prefilter_orphan_keys(["--flag", "--other", "v"], parser)
+
+
+def test_N4_prefilter_option_at_tail_raises():
+    parser = _FakeParser([_FakeAction(["--k"], nargs=None)])
+    try:
+        ActionCommand._prefilter_orphan_keys(["--k"], parser)
+        assert False, "expected UnknownArgumentError"
+    except UnknownArgumentError as e:
+        msg = str(e)
+        assert "Missing value for option(s):" in msg
+        assert "--k" in msg
+
+
+def test_N5_prefilter_adjacent_options_raises():
+    parser = _FakeParser([_FakeAction(["--k"], nargs=None)])
+    try:
+        ActionCommand._prefilter_orphan_keys(["--k", "--other", "v"], parser)
+        assert False, "expected UnknownArgumentError"
+    except UnknownArgumentError as e:
+        assert "--k" in str(e)
+
+
+def test_N6_prefilter_normal_pair_no_raise():
+    parser = _FakeParser([_FakeAction(["--k"], nargs=None)])
+    ActionCommand._prefilter_orphan_keys(["--k", "v"], parser)
+
+
+def test_N7_prefilter_multiple_orphans_all_reported():
+    parser = _FakeParser([_FakeAction(["--flag"], nargs=0)])
+    try:
+        ActionCommand._prefilter_orphan_keys(
+            ["--k1", "--k2", "--k3"], parser)
+        assert False, "expected UnknownArgumentError"
+    except UnknownArgumentError as e:
+        msg = str(e)
+        assert "--k1" in msg
+        assert "--k2" in msg
+
+
+# ============================================================
+# O. _build_oversized_hint 白盒
+# ============================================================
+def test_O1_oversized_hint_empty_returns_empty_str():
+    ac = _make_action_command()
+    assert ac._build_oversized_hint([]) == ""
+
+
+def test_O2_oversized_hint_single_entry_full_text():
+    ac = _make_action_command()
+    hint = ac._build_oversized_hint([("A.B.C", 31, "A.B", "T")])
+    assert "MAX_INPUT_DEPTH=30" in hint
+    assert "depth=31" in hint
+    assert "--A.B.C" in hint
+    assert "under --A.B" in hint
+    assert "type: T" in hint
+    assert "Use --cli-input-json file://" in hint
+
+
+def test_O3_oversized_hint_missing_type_falls_back_to_unknown():
+    ac = _make_action_command()
+    hint = ac._build_oversized_hint([("A.X", 31, "A", "")])
+    assert "type: unknown" in hint
+
+
+def test_O4_oversized_hint_multiple_entries_each_on_own_line():
+    ac = _make_action_command()
+    hint = ac._build_oversized_hint([
+        ("A.X", 31, "A", "T1"),
+        ("B.Y", 32, "B", "T2"),
+    ])
+    assert "--A.X" in hint
+    assert "--B.Y" in hint
+    assert "depth=31" in hint
+    assert "depth=32" in hint
+
+
+# ============================================================
+# P. _extract_deep_nested_args 白盒边界
+# ============================================================
+def test_P1_extract_empty_remaining_returns_as_is():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+    extra = OrderedDict()
+    oversized = []
+    out = ac._extract_deep_nested_args([], extra, oversized)
+    assert out == []
+    assert extra == OrderedDict()
+    assert oversized == []
+
+
+def test_P2_extract_loader_raises_returns_original():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _BadLoader(object):
+        def get_unfold_param_info(self, *a, **kw):
+            raise RuntimeError("boom")
+    ac._cli_data = _BadLoader()
+    remaining = ["--Foo.Bar", "v"]
+    extra = OrderedDict()
+    oversized = []
+    out = ac._extract_deep_nested_args(remaining, extra, oversized)
+    assert out == remaining
+    assert extra == OrderedDict()
+
+
+def test_P3_extract_no_truncated_returns_original():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _NoTrunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Foo": {"recursive_truncated": False}}
+    ac._cli_data = _NoTrunc()
+    remaining = ["--Foo.Extra", "v"]
+    out = ac._extract_deep_nested_args(remaining, OrderedDict(), [])
+    assert out == remaining
+
+
+def test_P4_extract_service_model_raises_still_works():
+    """get_service_model 抛异常不会影响主流程（service_model=None 时仍能收集）。"""
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _PartLoader(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "T"}}
+
+        def get_service_model(self, *a, **kw):
+            raise RuntimeError("no schema")
+    ac._cli_data = _PartLoader()
+    extra = OrderedDict()
+    oversized = []
+    out = ac._extract_deep_nested_args(
+        ["--Root.0.Sub", "v"], extra, oversized)
+    assert out == []
+    assert extra == {"Root.0.Sub": "v"}
+
+
+def test_P5_extract_non_dash_token_kept_in_new_remaining():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "T"}}
+
+        def get_service_model(self, *a, **kw):
+            return {"objects": {}}
+    ac._cli_data = _Trunc()
+    out = ac._extract_deep_nested_args(
+        ["stray_positional"], OrderedDict(), [])
+    assert out == ["stray_positional"]
+
+
+def test_P6_extract_non_matching_pair_kept_wholesale():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "T"}}
+
+        def get_service_model(self, *a, **kw):
+            return {"objects": {}}
+    ac._cli_data = _Trunc()
+    out = ac._extract_deep_nested_args(
+        ["--OtherKey", "v1", "v2"], OrderedDict(), [])
+    assert out == ["--OtherKey", "v1", "v2"]
+
+
+def test_P7_extract_valueless_non_matching_key_kept():
+    ac = _make_action_command(call_mode=Options_define.CliUnfoldArgument)
+
+    class _Trunc(object):
+        def get_unfold_param_info(self, *a, **kw):
+            return {"Root.0": {"recursive_truncated": True,
+                               "recursive_type": "T"}}
+
+        def get_service_model(self, *a, **kw):
+            return {"objects": {}}
+    ac._cli_data = _Trunc()
+    out = ac._extract_deep_nested_args(["--WhoAmI"], OrderedDict(), [])
+    assert out == ["--WhoAmI"]
+
+
+# ============================================================
+# 允许直接 `python3 tests/test_command.py` 运行（无 pytest 环境）
+# ============================================================
+if __name__ == "__main__":
+    import traceback
+
+    tests = [
+        (name, obj) for name, obj in sorted(globals().items())
+        if name.startswith("test_") and callable(obj)
+    ]
+    passed = failed = skipped = 0
+    failures = []
+    for name, fn in tests:
+        try:
+            fn()
+            print("PASS  %s" % name)
+            passed += 1
+        except Exception as e:
+            cls = e.__class__.__name__
+            if cls in ("_SkipException", "Skipped"):
+                print("SKIP  %s  (%s)" % (name, e))
+                skipped += 1
+            else:
+                print("FAIL  %s" % name)
+                traceback.print_exc()
+                failed += 1
+                failures.append(name)
+    print("\n=========================================")
+    print("total=%d  passed=%d  failed=%d  skipped=%d"
+          % (len(tests), passed, failed, skipped))
+    if failures:
+        print("failed tests:")
+        for n in failures:
+            print("  - %s" % n)
+    sys.exit(1 if failed else 0)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -41,8 +41,9 @@ except ImportError:
 
 _TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.dirname(_TESTS_DIR)
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
+while _REPO_ROOT in sys.path:
+    sys.path.remove(_REPO_ROOT)
+sys.path.insert(0, _REPO_ROOT)
 
 # ============================================================
 # 通用：屏蔽 plugin 加载（很多 tccli 插件依赖外部 SDK，环境可能没装）

--- a/tests/test_document_handler.py
+++ b/tests/test_document_handler.py
@@ -1,0 +1,747 @@
+# -*- coding: utf-8 -*-
+"""
+recursive-nesting-30：document_handler 单元测试。
+
+覆盖目标：
+  1. CLIDocumentHandler / ServiceDocumentHandler / ActionDocumentHandler
+     三个类的 doc_help / 子方法行为；
+2. 自引用截断（members 为字符串）时正确渲染 recursive 提示占位；
+  3. _json_format / _handle_object_members / _complex_object_doc / _unfold_complex_object
+     在 Array / Object / 基础类型 / 截断占位四种 members 形态下的分支；
+  4. example / input_example / output_example / 各种 getters。
+"""
+
+import os
+import sys
+
+import pytest
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_TESTS_DIR)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import tccli.plugin as _plg  # noqa: E402
+
+_plg.import_plugins = lambda: {}
+
+from tccli import document_handler as dh  # noqa: E402
+
+
+# ============================================================
+# 工具：构造一个 fake doc 对象，把所有写入累积到 lines 里
+# ============================================================
+class _FakeStyle(object):
+    def __init__(self, parent):
+        self._p = parent
+        self.indentation = 0
+
+    def h1(self, text):
+        self._p.lines.append("[H1]" + text)
+
+    def h2(self, text):
+        self._p.lines.append("[H2]" + text)
+
+    def indent(self):
+        self.indentation += 2
+        self._p.lines.append("[INDENT]")
+
+    def dedent(self):
+        self.indentation = max(0, self.indentation - 2)
+        self._p.lines.append("[DEDENT]")
+
+    def new_line(self):
+        self._p.lines.append("[NL]")
+
+    def spaces(self):
+        return " " * self.indentation
+
+
+class _FakeDoc(object):
+    def __init__(self):
+        self.lines = []
+        self.style = _FakeStyle(self)
+
+    def write(self, text):
+        self.lines.append(text)
+
+    def doc_title(self, text):
+        self.lines.append("[TITLE]" + text)
+
+    def doc_title_indent(self, text):
+        self.lines.append("[TITLE_INDENT]" + text)
+
+    def doc_description(self, text):
+        self.lines.append("[DESC]" + text)
+
+    def doc_description_indent(self, text):
+        self.lines.append("[DESC_INDENT]" + str(text))
+
+
+def _flat(doc):
+    return "\n".join(str(x) for x in doc.lines)
+
+
+# ============================================================
+# 工具：构造一个 stub Loader，按需注入返回值
+# ============================================================
+class _StubLoader(object):
+    def __init__(self, **overrides):
+        self._overrides = overrides
+
+    def __getattr__(self, name):
+        if name in self._overrides:
+            val = self._overrides[name]
+            if callable(val):
+                return val
+            return lambda *a, **kw: val
+        raise AttributeError(name)
+
+
+def _patch_loader(handler, **overrides):
+    """把 handler 的 _cli_data 替换为 stub。"""
+    handler._cli_data = _StubLoader(**overrides)
+    return handler
+
+
+# ============================================================
+# A. CLIDocumentHandler
+# ============================================================
+def test_A1_cli_description_writes_h2_and_text():
+    doc = _FakeDoc()
+    h = dh.CLIDocumentHandler(doc)
+    _patch_loader(h, get_description=lambda: "tccli root description")
+    h.description()
+    flat = _flat(doc)
+    assert "[H2]Description" in flat
+    assert "tccli root description" in flat
+
+
+def test_A2_cli_configure_writes_h2_and_text():
+    doc = _FakeDoc()
+    h = dh.CLIDocumentHandler(doc)
+    _patch_loader(h, get_configure=lambda: "configure-snippet")
+    h.configure()
+    flat = _flat(doc)
+    assert "[H2]Configure" in flat
+    assert "configure-snippet" in flat
+
+
+def test_A3_cli_usage_writes_h2_and_text():
+    doc = _FakeDoc()
+    h = dh.CLIDocumentHandler(doc)
+    _patch_loader(h, get_usage=lambda: "tccli usage line")
+    h.usage()
+    flat = _flat(doc)
+    assert "[H2]Usage" in flat
+    assert "tccli usage line" in flat
+
+
+def test_A4_cli_options_lists_each_option():
+    doc = _FakeDoc()
+    h = dh.CLIDocumentHandler(doc)
+    _patch_loader(h, get_options=lambda: {"--foo": "foo desc", "--bar": "bar desc"})
+    h.options()
+    flat = _flat(doc)
+    assert "[H2]Options" in flat
+    assert "--foo" in flat and "foo desc" in flat
+    assert "--bar" in flat and "bar desc" in flat
+
+
+def test_A5_cli_available_services_brief_default():
+    doc = _FakeDoc()
+    h = dh.CLIDocumentHandler(doc)
+    _patch_loader(h, get_available_services=lambda: {"cvm": [], "billing": []})
+    h.available_services(detailed=False)
+    flat = _flat(doc)
+    assert "[H2]Available Services" in flat
+    assert "[cvm]" in flat
+    assert "[billing]" in flat
+    assert "tccli help --detail" in flat
+
+
+def test_A6_cli_available_services_detailed():
+    doc = _FakeDoc()
+    h = dh.CLIDocumentHandler(doc)
+    _patch_loader(
+        h,
+        get_available_services=lambda: {"svc-a": [], "svc-b": []},
+        get_service_default_version=lambda s: "2024-01-01",
+        get_service_description=lambda s, v: ("desc-" + s) if s == "svc-a" else "",
+    )
+    h.available_services(detailed=True)
+    flat = _flat(doc)
+    assert "svc-a" in flat
+    assert "desc-svc-a" in flat
+    # svc-b 没 description，不应崩溃且也应能完成 new_line
+    assert "svc-b" in flat
+
+
+def test_A7_cli_doc_help_combines_all_sections():
+    doc = _FakeDoc()
+    h = dh.CLIDocumentHandler(doc)
+    _patch_loader(
+        h,
+        get_usage=lambda: "tccli usage",
+        get_options=lambda: {"--x": "x"},
+        get_available_services=lambda: {"svc": []},
+    )
+    h.doc_help(detailed=False)
+    flat = _flat(doc)
+    assert "[H2]Usage" in flat
+    assert "[H2]Options" in flat
+    assert "[H2]Available Services" in flat
+
+
+# ============================================================
+# B. ServiceDocumentHandler
+# ============================================================
+def test_B1_service_available_versions_marks_first_as_recommended():
+    doc = _FakeDoc()
+    h = dh.ServiceDocumentHandler(doc, "cvm", "2017-03-12")
+    _patch_loader(h, get_available_services=lambda: {"cvm": ["2017-03-12", "2016-09-01"]})
+    h.available_versions()
+    flat = _flat(doc)
+    assert "2017-03-12  (recommended)" in flat
+    assert "2016-09-01" in flat
+
+
+def test_B2_service_description_handles_none():
+    doc = _FakeDoc()
+    h = dh.ServiceDocumentHandler(doc, "cvm", "2017-03-12")
+    _patch_loader(h, get_service_description=lambda s, v: None)
+    h.description()
+    flat = _flat(doc)
+    assert "[H2]Description" in flat
+
+
+def test_B3_service_usage():
+    doc = _FakeDoc()
+    h = dh.ServiceDocumentHandler(doc, "cvm", "2017-03-12")
+    _patch_loader(h, get_service_usage=lambda s: "tccli cvm usage")
+    h.usage()
+    flat = _flat(doc)
+    assert "tccli cvm usage" in flat
+
+
+def test_B4_service_options():
+    doc = _FakeDoc()
+    h = dh.ServiceDocumentHandler(doc, "cvm", "2017-03-12")
+    _patch_loader(h, get_service_options=lambda s: {"--profile": "profile desc"})
+    h.options()
+    flat = _flat(doc)
+    assert "--profile" in flat
+    assert "profile desc" in flat
+
+
+def test_B5_service_available_actions_brief():
+    doc = _FakeDoc()
+    h = dh.ServiceDocumentHandler(doc, "cvm", "2017-03-12")
+    _patch_loader(
+        h,
+        get_actions_info=lambda s, v: {"DescribeInstances": {"name": "DescribeInstances desc"}},
+    )
+    h.available_actions(detail=False)
+    flat = _flat(doc)
+    assert "<DescribeInstances>" in flat
+    assert "tccli cvm help --detail" in flat
+
+
+def test_B6_service_available_actions_detail():
+    doc = _FakeDoc()
+    h = dh.ServiceDocumentHandler(doc, "cvm", "2017-03-12")
+    _patch_loader(
+        h,
+        get_actions_info=lambda s, v: {"A1": {"name": "A1 desc"}, "A2": {"name": "A2 desc"}},
+    )
+    h.available_actions(detail=True)
+    flat = _flat(doc)
+    assert "[TITLE_INDENT]A1" in flat
+    assert "A1 desc" in flat
+    assert "[TITLE_INDENT]A2" in flat
+
+
+def test_B7_service_doc_help_combines_all_sections():
+    doc = _FakeDoc()
+    h = dh.ServiceDocumentHandler(doc, "cvm", "2017-03-12")
+    _patch_loader(
+        h,
+        get_available_services=lambda: {"cvm": ["2017-03-12"]},
+        get_service_description=lambda s, v: "cvm desc",
+        get_service_usage=lambda s: "cvm usage",
+        get_service_options=lambda s: {"--profile": "p"},
+        get_actions_info=lambda s, v: {"X": {"name": "x"}},
+    )
+    h.doc_help(detail=False)
+    flat = _flat(doc)
+    assert "[H2]Available Versions" in flat
+    assert "[H2]Description" in flat
+    assert "[H2]Usage" in flat
+    assert "[H2]Options" in flat
+    assert "[H2]Available Actions" in flat
+
+
+# ============================================================
+# C. ActionDocumentHandler 基础方法
+# ============================================================
+def _make_action_handler(doc=None, action="Foo"):
+    if doc is None:
+        doc = _FakeDoc()
+    h = dh.ActionDocumentHandler(doc, "svc", "2024-01-01", action)
+    return h
+
+
+def test_C1_action_description():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(h, get_action_description=lambda s, v, a: "action desc")
+    h.description()
+    flat = _flat(doc)
+    assert "[H2]Description" in flat
+    assert "svc-2024-01-01-Foo" in flat
+    assert "action desc" in flat
+
+
+def test_C2_action_usage():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(h, get_action_usage=lambda s, a: "tccli svc Foo")
+    h.usage()
+    flat = _flat(doc)
+    assert "tccli svc Foo" in flat
+
+
+def test_C3_action_options_brief():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    # keys 中最后一个被 pop 后插入到首位 —— 这里给 3 个 key 验证排序行为
+    _patch_loader(
+        h,
+        get_action_options=lambda s, a: {"--profile": "p", "--region": "r", "--help": "h"},
+    )
+    h.options(detail=False)
+    flat = _flat(doc)
+    assert "[--help]" in flat or "[--profile]" in flat or "[--region]" in flat
+    # brief 模式都用 [name] 形式
+    assert "[--profile]" in flat
+    assert "[--region]" in flat
+
+
+def test_C4_action_options_detail():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(
+        h,
+        get_action_options=lambda s, a: {"--profile": "profile desc", "--help": "help desc"},
+    )
+    h.options(detail=True)
+    flat = _flat(doc)
+    assert "--profile" in flat and "profile desc" in flat
+    assert "--help" in flat and "help desc" in flat
+
+
+# ============================================================
+# D. _json_format / _handle_object_members 各分支
+# ============================================================
+def test_D1_json_format_array_of_base_type_top_level():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    # indentation == 0 走 doc_description 分支
+    h._json_format({"type": "Array", "members": ["string"]})
+    flat = _flat(doc)
+    assert "[string ...]" in flat
+
+
+def test_D2_json_format_array_of_base_type_indented():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    doc.style.indentation = 4
+    h._json_format({"type": "Array", "members": ["string"]})
+    flat = _flat(doc)
+    # indentation > 2 走 doc.write 分支
+    assert "[string ...]" in flat
+
+
+def test_D3_json_format_array_recursive_truncation():
+    """D3: Array 自引用截断 → 渲染 recursive 提示占位。"""
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h._json_format({"type": "Array", "members": ["AllocationRuleExpression"]})
+    flat = _flat(doc)
+    assert "<recursive:" in flat
+    assert "AllocationRuleExpression" in flat
+
+
+def test_D5_json_format_array_of_object():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    members = {"K": {"type": "String", "members": "string"}}
+    h._json_format({"type": "Array", "members": [members]})
+    flat = _flat(doc)
+    assert '"K": String' in flat
+    assert "..." in flat
+
+
+def test_D6_json_format_object_base_type_returns_quietly():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    # type != Array 且 members 是 BASE_TYPE 元素 → 直接 return，不写入
+    h._json_format({"type": "string", "members": "string"})
+    assert doc.lines == []
+
+
+def test_D7_json_format_object_recursive_truncation():
+    """D7: 非 Array 自引用截断 → 渲染 recursive 提示占位。"""
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h._json_format({"type": "Node", "members": "Node"})
+    flat = _flat(doc)
+    assert "<recursive:" in flat
+    assert "Node" in flat
+
+
+def test_D8_json_format_object_full_dict_members():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    members = {"X": {"type": "String", "members": "string"}}
+    h._json_format({"type": "Inner", "members": members})
+    flat = _flat(doc)
+    assert '"X": String' in flat
+
+
+def test_D9_handle_object_members_array_field_inside():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    members = {
+        "A": {"type": "String", "members": "string"},
+        "B": {"type": "Array", "members": ["string"]},
+    }
+    h._handle_object_members(members, "Object")
+    flat = _flat(doc)
+    assert '"A": String' in flat
+    assert '"B": ' in flat
+    assert "[string ...]" in flat
+
+
+def test_D10_handle_object_members_nested_object_field():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    members = {
+        "Inner": {
+            "type": "Inner",
+            "members": {"X": {"type": "String", "members": "string"}},
+        },
+    }
+    h._handle_object_members(members, "Object")
+    flat = _flat(doc)
+    assert '"X": String' in flat
+
+
+# ============================================================
+# E. _unfold_complex_object / _complex_object_doc
+# ============================================================
+def test_E1_unfold_complex_object_skips_base_type():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    # 非 Array 且 members 是 BASE_TYPE → 直接 return
+    h._unfold_complex_object({"type": "string", "members": "string"})
+    assert doc.lines == []
+
+
+def test_E2_unfold_complex_object_skips_recursive_truncation():
+    """E2: 非 Array 自引用截断（members=类型名字符串）应直接 return。"""
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h._unfold_complex_object({"type": "Node", "members": "Node"})
+    # 不应写入 JSON Syntax 标题
+    flat = _flat(doc)
+    assert "JSON Syntax" not in flat
+
+
+def test_E3_unfold_complex_object_writes_json_syntax():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h._unfold_complex_object({
+        "type": "Inner",
+        "members": {"X": {"type": "String", "members": "string"}},
+    })
+    flat = _flat(doc)
+    assert "JSON Syntax" in flat
+    assert '"X": String' in flat
+
+
+def test_E4_complex_object_doc_skips_base_type_members():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h._complex_object_doc({"members": "string"}, "Available Parameters")
+    assert doc.lines == []
+
+
+def test_E5_complex_object_doc_skips_recursive_truncation():
+    """E5: members 为类型名字符串（自引用截断）→ 直接 return，不递归。"""
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h._complex_object_doc({"members": "Node"}, "Available Parameters")
+    # 不应进入 indent / 子成员遍历
+    assert doc.lines == []
+
+
+def test_E6_complex_object_doc_recurses_into_dict_members():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    members = {
+        "Sub": {
+            "type": "String",
+            "type_name": "String",
+            "required": "Required",
+            "document": "doc-of-sub",
+            "members": "string",
+        }
+    }
+    h._complex_object_doc({"members": members}, "Available Parameters")
+    flat = _flat(doc)
+    assert "doc-of-sub" in flat
+
+
+def test_E7_complex_object_doc_skips_recursive_subfield():
+    """E7: 子字段 members 为类型名字符串时不再继续递归（避免自引用循环）。"""
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    members = {
+        "Self": {
+            "type": "Node",
+            "type_name": "Node",
+            "required": "Optional",
+            "document": "self ref",
+            "members": "Node",  # ← 自引用占位
+        }
+    }
+    h._complex_object_doc({"members": members}, "Available Parameters")
+    flat = _flat(doc)
+    assert "self ref" in flat
+
+
+# ============================================================
+# F. _param_type / _doc_title
+# ============================================================
+def test_F1_param_type_array():
+    h = _make_action_handler()
+    out = h._param_type({"type": "Array", "type_name": "ItemType"})
+    assert out == "Array of ItemType"
+
+
+def test_F2_param_type_non_array():
+    h = _make_action_handler()
+    out = h._param_type({"type": "String", "type_name": "String"})
+    assert out == "String"
+
+
+def test_F3_doc_title_available_parameters_includes_required():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h._doc_title("Available Parameters", "Foo",
+                 {"type": "String", "type_name": "String", "required": "Required"})
+    flat = _flat(doc)
+    assert "--Foo" in flat
+    assert "String" in flat
+    assert "Required" in flat
+
+
+def test_F4_doc_title_output_parameter_form():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h._doc_title("Output Parameter", "Bar",
+                 {"type": "String", "type_name": "String"})
+    flat = _flat(doc)
+    assert "Bar -> (String)" in flat
+
+
+# ============================================================
+# G. _base_parameter / available_parameter / output_parameter
+# ============================================================
+def _stub_get_param_info(params):
+    def _impl(s, v, a):
+        return params
+    return _impl
+
+
+def test_G1_base_parameter_empty_writes_无():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(
+        h,
+        get_param_info=_stub_get_param_info({}),
+        get_output_param_info=_stub_get_param_info({}),
+    )
+    h._base_parameter("Available Parameters", detail=False)
+    flat = _flat(doc)
+    assert "[H2]Available Parameters" in flat
+    assert "无" in flat
+
+
+def test_G2_base_parameter_brief_lists_titles_and_help_hint():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(
+        h,
+        get_param_info=_stub_get_param_info({}),
+        get_output_param_info=_stub_get_param_info({
+            "RequestId": {
+                "type": "String", "type_name": "String",
+                "members": "string",
+                "required": None,
+                "document": "request-id-doc",
+            }
+        }),
+    )
+    h._base_parameter("Output Parameter", detail=False)
+    flat = _flat(doc)
+    assert "RequestId -> (String)" in flat
+    assert "tccli svc Foo help --detail" in flat
+
+
+def test_G3_base_parameter_detail_writes_doc_and_recurses():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(
+        h,
+        get_param_info=_stub_get_param_info({
+            "RuleList": {
+                "type": "Inner", "type_name": "Inner",
+                "required": "Required",
+                "document": "rule-list-doc",
+                "members": {
+                    "Sub": {
+                        "type": "String", "type_name": "String",
+                        "members": "string",
+                        "required": "Optional",
+                        "document": "sub-doc",
+                    }
+                },
+            }
+        }),
+        get_output_param_info=_stub_get_param_info({}),
+    )
+    h._base_parameter("Available Parameters", detail=True)
+    flat = _flat(doc)
+    assert "rule-list-doc" in flat
+    assert "JSON Syntax" in flat
+    assert "sub-doc" in flat
+
+
+def test_G4_available_parameter_and_output_parameter_call_through():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(
+        h,
+        get_param_info=_stub_get_param_info({}),
+        get_output_param_info=_stub_get_param_info({}),
+    )
+    h.available_parameter(detail=False)
+    h.output_parameter(detail=False)
+    flat = _flat(doc)
+    assert "[H2]Available Parameters" in flat
+    assert "[H2]Output Parameter" in flat
+
+
+def test_G5_get_param_info_method_property():
+    h = _make_action_handler()
+    pim = h.param_info_method
+    assert "Available Parameters" in pim
+    assert "Output Parameter" in pim
+
+
+# ============================================================
+# H. example / input_example / output_example
+# ============================================================
+def test_H1_input_example_with_params():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h.input_example(["--Id 1", "--Name foo"])
+    flat = _flat(doc)
+    assert "Input:" in flat
+    assert "--cli-unfold-argument" in flat
+    assert "--Id 1" in flat
+    assert "--Name foo" in flat
+
+
+def test_H2_input_example_empty():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h.input_example([])
+    flat = _flat(doc)
+    assert "Input:" in flat
+    # 空入参不应抛异常
+
+
+def test_H3_output_example_writes_under_indent():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    h.output_example("{\"R\":1}")
+    flat = _flat(doc)
+    assert "Output:" in flat
+    assert "{\"R\":1}" in flat
+
+
+def test_H4_example_iterates_loader_examples():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(
+        h,
+        generate_cli_example=lambda s, v, a: [
+            {"title": "demo", "document": "demo doc",
+             "input": ["--A x"], "output": "{\"R\":1}"},
+        ],
+    )
+    h.example()
+    flat = _flat(doc)
+    assert "[H2]Examples" in flat
+    assert "Example 1: demo" in flat
+    assert "demo doc" in flat
+    assert "--A x" in flat
+
+
+# ============================================================
+# I. doc_help 端到端（detail=True 与 detail=False）
+# ============================================================
+def test_I1_action_doc_help_detail_false_skips_description_and_example():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(
+        h,
+        get_action_description=lambda s, v, a: "should-not-appear",
+        get_action_usage=lambda s, a: "tccli svc Foo",
+        get_action_options=lambda s, a: {"--help": "h"},
+        get_param_info=_stub_get_param_info({}),
+        get_output_param_info=_stub_get_param_info({}),
+        generate_cli_example=lambda s, v, a: [],
+    )
+    h.doc_help(detail=False)
+    flat = _flat(doc)
+    # detail=False 跳过 description 与 example
+    assert "should-not-appear" not in flat
+    assert "[H2]Examples" not in flat
+    assert "[H2]Usage" in flat
+    assert "[H2]Available Parameters" in flat
+    assert "[H2]Output Parameter" in flat
+
+
+def test_I2_action_doc_help_detail_true_includes_description_and_example():
+    doc = _FakeDoc()
+    h = _make_action_handler(doc)
+    _patch_loader(
+        h,
+        get_action_description=lambda s, v, a: "real action description",
+        get_action_usage=lambda s, a: "tccli svc Foo",
+        get_action_options=lambda s, a: {"--help": "h"},
+        get_param_info=_stub_get_param_info({}),
+        get_output_param_info=_stub_get_param_info({}),
+        generate_cli_example=lambda s, v, a: [
+            {"title": "t", "document": "d", "input": [], "output": "o"}
+        ],
+    )
+    h.doc_help(detail=True)
+    flat = _flat(doc)
+    assert "real action description" in flat
+    assert "[H2]Examples" in flat
+    assert "Example 1: t" in flat

--- a/tests/test_document_handler.py
+++ b/tests/test_document_handler.py
@@ -79,7 +79,13 @@ class _FakeDoc(object):
 
 
 def _flat(doc):
-    return "\n".join(str(x) for x in doc.lines)
+    parts = []
+    for x in doc.lines:
+        try:
+            parts.append(str(x))
+        except UnicodeEncodeError:
+            parts.append(x.encode("utf-8"))
+    return "\n".join(parts)
 
 
 # ============================================================
@@ -565,7 +571,7 @@ def _stub_get_param_info(params):
     return _impl
 
 
-def test_G1_base_parameter_empty_writes_无():
+def test_G1_base_parameter_empty_writes():
     doc = _FakeDoc()
     h = _make_action_handler(doc)
     _patch_loader(

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -749,7 +749,7 @@ def test_K1_get_service_default_version_uses_first():
         ver = ld.get_service_default_version("cvm")
         assert ver in avail["cvm"]
     finally:
-        _u.Utils.file_existed = saved
+        _u.Utils.file_existed = staticmethod(saved)
 
 
 def test_K2_get_service_all_version_actions_real_cvm():
@@ -825,7 +825,7 @@ def test_L1_add_array_item_expand_to_max():
         # 不应越界产生 "10"
         assert ["A", "10", "B"] not in out
     finally:
-        _u.Utils.file_existed = saved
+        _u.Utils.file_existed = staticmethod(saved)
 
 
 def test_L2_add_array_item_with_param_array_via_unfold():
@@ -844,7 +844,7 @@ def test_L2_add_array_item_with_param_array_via_unfold():
         non_zero = [k for k in unfold if k.startswith("Root.Children.") and not k.endswith(".0")]
         assert len(non_zero) > 0
     finally:
-        _u.Utils.file_existed = saved
+        _u.Utils.file_existed = staticmethod(saved)
 
 
 # ============================================================
@@ -893,7 +893,7 @@ def test_M2_filling_array_index_gt_zero_downgrades_required():
                 assert v["required"] == "Optional"
                 break
     finally:
-        _u.Utils.file_existed = saved
+        _u.Utils.file_existed = staticmethod(saved)
 
 
 def test_M3_filling_path_traverses_array_member_dict():

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,1209 @@
+# -*- coding: utf-8 -*-
+"""
+针对 tccli.loaders 的单元测试。
+
+重点覆盖：
+1. 普通（无环）schema：保证修复未引入回归。
+2. 自引用（直接 / 间接 / 兄弟共享类型）schema：核心修复点。
+3. _generate_param_skeleton：自引用处以字符串占位表示（<recursive: fill '<field>' with a JSON object of type <T> (self-referenced)>）。
+4. _get_unfold_param_info：自引用接口可被 unfold，不再 RecursionError。
+5. _filling_unfold_param_info：截断点 type=Object，文档附加提示。
+6. 公共方法 get_param_info / get_output_param_info / generate_param_skeleton /
+   get_unfold_param_info 的端到端行为。
+7. 真实仓库数据：billing 含自引用接口、cvm 普通接口。
+
+使用 pytest 风格：每个 test_* 函数内 assert，文件末尾不再调用，pytest 自动发现。
+"""
+import os
+import sys
+
+try:
+    import pytest
+    _HAS_PYTEST = True
+except ImportError:
+    _HAS_PYTEST = False
+
+    class _SkipException(Exception):
+        pass
+
+    class _PytestStub(object):
+        @staticmethod
+        def skip(msg):
+            raise _SkipException(msg)
+
+    pytest = _PytestStub()  # type: ignore
+
+# 确保 tccli 可被导入
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_TESTS_DIR)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# 屏蔽 plugin import 的开销/副作用，使纯静态测试可在任何环境下运行
+import tccli.plugin as _plg  # noqa: E402
+
+_plg.import_plugins = lambda: {}
+
+from tccli.loaders import Loader, BASE_TYPE  # noqa: E402
+
+
+# ============================================================
+# 工具：构造一个内存版 Loader，注入指定 service_model
+# ============================================================
+def _make_loader(model):
+    """返回一个 Loader 实例，其 get_service_model 直接返回给定 model。"""
+    ld = Loader()
+    ld.get_service_model = lambda service, version: model
+    return ld
+
+
+def _model(actions, objects):
+    return {"metadata": {}, "actions": actions, "objects": objects}
+
+
+def _action(input_name, output_name=None):
+    out = {"input": input_name, "name": input_name.replace("Request", "")}
+    if output_name:
+        out["output"] = output_name
+    return out
+
+
+# ============================================================
+# A. 普通场景回归
+# ============================================================
+def test_A1_basic_types_no_regression():
+    """A1: 仅基础类型字段 —— 输出应与修改前一致。"""
+    objects = {
+        "FooRequest": {
+            "members": [
+                {"name": "Id", "type": "string", "member": "string", "document": "id", "required": True},
+                {"name": "Count", "type": "int", "member": "int64", "document": "count", "required": False},
+            ],
+        },
+    }
+    actions = {"Foo": _action("FooRequest")}
+    ld = _make_loader(_model(actions, objects))
+
+    info = ld.get_param_info("svc", "v", "Foo")
+    assert set(info.keys()) == {"Id", "Count"}
+    assert info["Id"]["type"] == "String"
+    assert info["Id"]["type_name"] == "String"
+    assert info["Id"]["required"] == "Required"
+    assert info["Id"]["members"] == "string"
+    assert info["Count"]["type"] == "Integer"
+    assert info["Count"]["required"] == "Optional"
+
+
+def test_A2_nested_object_full_expand():
+    """A2: 嵌套 Object 完整展开。"""
+    objects = {
+        "BarRequest": {
+            "members": [
+                {"name": "Outer", "type": "object", "member": "Inner", "document": "", "required": True},
+            ],
+        },
+        "Inner": {
+            "members": [
+                {"name": "Leaf", "type": "string", "member": "string", "document": "leaf", "required": True},
+            ],
+        },
+    }
+    actions = {"Bar": _action("BarRequest")}
+    ld = _make_loader(_model(actions, objects))
+
+    info = ld.get_param_info("svc", "v", "Bar")
+    # Outer 是嵌套 object，members 应是 dict（已展开）
+    assert isinstance(info["Outer"]["members"], dict)
+    assert "Leaf" in info["Outer"]["members"]
+    assert info["Outer"]["members"]["Leaf"]["type"] == "String"
+
+
+def test_A3_list_of_object_full_expand():
+    """A3: List<ComplexObject> 完整展开。"""
+    objects = {
+        "BazRequest": {
+            "members": [
+                {"name": "Items", "type": "list", "member": "Item", "document": "", "required": True},
+            ],
+        },
+        "Item": {
+            "members": [
+                {"name": "Key", "type": "string", "member": "string", "document": "", "required": True},
+            ],
+        },
+    }
+    actions = {"Baz": _action("BazRequest")}
+    ld = _make_loader(_model(actions, objects))
+
+    info = ld.get_param_info("svc", "v", "Baz")
+    assert info["Items"]["type"] == "Array"
+    assert isinstance(info["Items"]["members"], list)
+    assert isinstance(info["Items"]["members"][0], dict)
+    assert "Key" in info["Items"]["members"][0]
+
+
+# ============================================================
+# B. 自引用环
+# ============================================================
+def _self_ref_list_model():
+    """Node { Children: List<Node> }"""
+    return _model(
+        actions={"Tree": _action("TreeRequest")},
+        objects={
+            "TreeRequest": {
+                "members": [
+                    {"name": "Root", "type": "object", "member": "Node",
+                     "document": "root", "required": True},
+                ],
+            },
+            "Node": {
+                "members": [
+                    {"name": "Value", "type": "string", "member": "string",
+                     "document": "v", "required": False},
+                    {"name": "Children", "type": "list", "member": "Node",
+                     "document": "children", "required": False},
+                ],
+            },
+        },
+    )
+
+
+def test_B1_direct_self_ref_via_list_does_not_crash():
+    """B1: List<Self> 直接自引用，必须不抛 RecursionError。"""
+    ld = _make_loader(_self_ref_list_model())
+    info = ld.get_param_info("svc", "v", "Tree")
+    # 顶层 Root 是 Node，已展开一层
+    assert isinstance(info["Root"]["members"], dict)
+    assert "Children" in info["Root"]["members"]
+    # Children 是自引用截断点，members 应是占位字符串列表 ["Node"]
+    children = info["Root"]["members"]["Children"]
+    assert children["type"] == "Array"
+    assert children["members"] == ["Node"]
+
+
+def test_B2_direct_self_ref_via_object_does_not_crash():
+    """B2: Object→Self 直接自引用。"""
+    objects = {
+        "LinkRequest": {
+            "members": [
+                {"name": "Head", "type": "object", "member": "LinkNode",
+                 "document": "", "required": True},
+            ],
+        },
+        "LinkNode": {
+            "members": [
+                {"name": "Val", "type": "string", "member": "string",
+                 "document": "", "required": True},
+                {"name": "Next", "type": "object", "member": "LinkNode",
+                 "document": "", "required": False},
+            ],
+        },
+    }
+    ld = _make_loader(_model({"Link": _action("LinkRequest")}, objects))
+
+    info = ld.get_param_info("svc", "v", "Link")
+    # Head.Next 是自引用截断点
+    next_field = info["Head"]["members"]["Next"]
+    # Object 自引用截断时 members 应被填成占位类型名（str）
+    assert next_field["members"] == "LinkNode"
+
+
+def test_B3_indirect_cycle_A_to_B_to_A():
+    """B3: 间接环 A→B→A。"""
+    objects = {
+        "GraphRequest": {
+            "members": [
+                {"name": "Start", "type": "object", "member": "A",
+                 "document": "", "required": True},
+            ],
+        },
+        "A": {
+            "members": [
+                {"name": "B", "type": "object", "member": "B",
+                 "document": "", "required": False},
+            ],
+        },
+        "B": {
+            "members": [
+                {"name": "A", "type": "object", "member": "A",
+                 "document": "", "required": False},
+            ],
+        },
+    }
+    ld = _make_loader(_model({"Graph": _action("GraphRequest")}, objects))
+
+    info = ld.get_param_info("svc", "v", "Graph")
+    # 路径 Start.B.A —— A 已在 visited 中，被截断
+    inner_a = info["Start"]["members"]["B"]["members"]["A"]
+    assert inner_a["members"] == "A"  # 占位字符串
+
+
+def test_B4_sibling_shared_type_not_falsely_truncated():
+    """B4: 两个兄弟字段共享同一类型 Common，不应被互相干扰。
+
+    如果实现错误地把 visited 当成"全局已见"集合，那么第二个兄弟字段会被误截断。
+    """
+    objects = {
+        "SibRequest": {
+            "members": [
+                {"name": "Left", "type": "object", "member": "Common",
+                 "document": "", "required": True},
+                {"name": "Right", "type": "object", "member": "Common",
+                 "document": "", "required": True},
+            ],
+        },
+        "Common": {
+            "members": [
+                {"name": "K", "type": "string", "member": "string",
+                 "document": "", "required": True},
+                {"name": "V", "type": "string", "member": "string",
+                 "document": "", "required": True},
+            ],
+        },
+    }
+    ld = _make_loader(_model({"Sib": _action("SibRequest")}, objects))
+
+    info = ld.get_param_info("svc", "v", "Sib")
+    assert isinstance(info["Left"]["members"], dict)
+    assert isinstance(info["Right"]["members"], dict)
+    assert {"K", "V"} <= set(info["Left"]["members"].keys())
+    assert {"K", "V"} <= set(info["Right"]["members"].keys())
+
+
+# ============================================================
+# C. 深度嵌套（无 max_depth 时全展开）
+# ============================================================
+def test_C1_deep_nesting_full_expand():
+    """C1: 深度嵌套（无环）应完整展开到最内层。"""
+    # 构造 XRequest -> L1 -> L2 -> L3 -> L4 -> L5 -> string
+    objects = {"XRequest": {"members": [
+        {"name": "F", "type": "object", "member": "L1",
+         "document": "", "required": True}
+    ]}}
+    for i in range(1, 5):
+        objects["L%d" % i] = {"members": [
+            {"name": "F", "type": "object", "member": "L%d" % (i + 1),
+             "document": "", "required": True}
+        ]}
+    objects["L5"] = {"members": [
+        {"name": "Leaf", "type": "string", "member": "string",
+         "document": "", "required": True}
+    ]}
+    actions = {"X": {"input": "XRequest", "name": "X"}}
+    ld = _make_loader(_model(actions, objects))
+
+    info = ld.get_param_info("svc", "v", "X")
+    cur = info["F"]
+    for _ in range(4):
+        assert isinstance(cur["members"], dict)
+        cur = cur["members"]["F"]
+    # 最里层应是 Leaf 完整展开
+    assert "Leaf" in cur["members"]
+    assert cur["members"]["Leaf"]["type"] == "String"
+
+
+# ============================================================
+# D. _generate_param_skeleton
+# ============================================================
+def test_D1_skeleton_self_ref_object_emits_placeholder():
+    """D1: Object 自引用 → 第二层以字符串占位表示。"""
+    objects = {
+        "LinkRequest": {
+            "members": [
+                {"name": "Head", "type": "object", "member": "LinkNode",
+                 "document": "", "required": True},
+            ],
+        },
+        "LinkNode": {
+            "members": [
+                {"name": "Val", "type": "string", "member": "string",
+                 "document": "", "required": True},
+                {"name": "Next", "type": "object", "member": "LinkNode",
+                 "document": "", "required": False},
+            ],
+        },
+    }
+    ld = _make_loader(_model({"Link": _action("LinkRequest")}, objects))
+    skeleton = ld.generate_param_skeleton("svc", "v", "Link")
+    # Head 完整展开一层
+    assert skeleton["Head"]["Val"] == "String"
+    # Head.Next 是自引用截断点：字符串占位，含字段名与类型名
+    assert skeleton["Head"]["Next"] == \
+        "<recursive: fill 'Next' with a JSON object of type LinkNode (self-referenced)>"
+
+
+def test_D2_skeleton_self_ref_list_emits_placeholder_list():
+    """D2: List<Self> → [字符串占位]（在 Tree 自引用模型上验证）。"""
+    ld = _make_loader(_self_ref_list_model())
+    skeleton = ld.generate_param_skeleton("svc", "v", "Tree")
+    # Root 是 Node，展开一层后 Children 出现自引用截断
+    assert skeleton["Root"]["Value"] == "String"
+    assert skeleton["Root"]["Children"] == [
+        "<recursive: fill 'Children' with a JSON object of type Node (self-referenced)>"
+    ]
+
+
+def test_D3_skeleton_normal_nested_unchanged():
+    """D3: 普通嵌套向后兼容。"""
+    objects = {
+        "Req": {
+            "members": [
+                {"name": "Items", "type": "list", "member": "Item",
+                 "document": "", "required": True},
+            ],
+        },
+        "Item": {
+            "members": [
+                {"name": "Key", "type": "string", "member": "string",
+                 "document": "", "required": True},
+            ],
+        },
+    }
+    ld = Loader()
+    skeleton = ld._generate_param_skeleton(objects["Req"]["members"], objects)
+    assert skeleton == {"Items": [{"Key": "String"}]}
+
+
+# ============================================================
+# E. _get_unfold_param_info
+# ============================================================
+def test_E1_unfold_self_ref_no_recursion_error():
+    """E1: 自引用接口 unfold 不抛 RecursionError，且包含截断点路径。"""
+    ld = _make_loader(_self_ref_list_model())
+    unfold = ld.get_unfold_param_info("svc", "v", "Tree")
+    keys = set(unfold.keys())
+    # Root.Value（基础类型 leaf）应该在
+    assert "Root.Value" in keys
+    # Root.Children.0 是被自引用截断的 leaf
+    assert "Root.Children.0" in keys
+
+
+def test_E2_unfold_recursion_truncated_path_marked_as_object():
+    """E2: 自引用截断点 type=Object 且文档含英文提示，并带稳定标记字段。"""
+    ld = _make_loader(_self_ref_list_model())
+    unfold = ld.get_unfold_param_info("svc", "v", "Tree")
+    trunc = unfold["Root.Children.0"]
+    assert trunc["type"] == "Object"
+    assert trunc["required"] == "Optional"
+    assert "self-referencing type" in trunc["document"]
+    assert "Node" in trunc["document"]
+    # 新增稳定字段（不依赖文案）：方案-B
+    assert trunc.get("recursive_truncated") is True
+    assert trunc.get("recursive_type") == "Node"
+
+
+def test_E3_unfold_sibling_shared_type_fully_expanded():
+    """E3: 兄弟字段共享同一非自引用类型，应分别独立完整展开。"""
+    objects = {
+        "XRequest": {
+            "members": [
+                {"name": "L", "type": "object", "member": "C",
+                 "document": "", "required": True},
+                {"name": "R", "type": "object", "member": "C",
+                 "document": "", "required": True},
+            ],
+        },
+        "C": {
+            "members": [
+                {"name": "K", "type": "string", "member": "string",
+                 "document": "", "required": True},
+            ],
+        },
+    }
+    ld = _make_loader(_model({"X": _action("XRequest")}, objects))
+    unfold = ld.get_unfold_param_info("svc", "v", "X")
+    assert "L.K" in unfold
+    assert "R.K" in unfold
+
+
+# ============================================================
+# F. _filling_unfold_param_info
+# ============================================================
+def test_F1_filling_truncated_marks_object_and_appends_doc():
+    """F1: 截断 leaf 的 type/type_name/required/document 行为。"""
+    ld = _make_loader(_self_ref_list_model())
+    unfold = ld.get_unfold_param_info("svc", "v", "Tree")
+    trunc = unfold["Root.Children.0"]
+    assert trunc["type"] == "Object"
+    assert trunc["type_name"] == "Node"  # 用占位类型名
+
+
+def test_F2_filling_normal_leaf_keeps_type():
+    """F2: 普通基础类型 leaf 类型不被改写。"""
+    ld = _make_loader(_self_ref_list_model())
+    unfold = ld.get_unfold_param_info("svc", "v", "Tree")
+    assert unfold["Root.Value"]["type"] == "String"
+    assert unfold["Root.Value"]["type_name"] == "String"
+    assert "self-referencing type" not in unfold["Root.Value"]["document"]
+    assert unfold["Root.Value"].get("recursive_truncated") is not True
+
+
+def test_F3_filling_secondary_check_for_list_placeholder():
+    """F3: 二次判定 —— 当一个字段的类型本身是自引用类型 Node，
+    且 Request 通过 List<Node> 引用它，截断点应被正确登记并在 _filling 阶段
+    通过"二次判定"识别为自引用占位。"""
+    objects = {
+        "XRequest": {
+            "members": [
+                {"name": "Roots", "type": "list", "member": "Node",
+                 "document": "", "required": True},
+            ],
+        },
+        "Node": {
+            "members": [
+                {"name": "Val", "type": "string", "member": "string",
+                 "document": "", "required": True},
+                {"name": "Children", "type": "list", "member": "Node",
+                 "document": "", "required": False},
+            ],
+        },
+    }
+    actions = {"X": {"input": "XRequest", "name": "X"}}
+    ld = _make_loader(_model(actions, objects))
+    unfold = ld.get_unfold_param_info("svc", "v", "X")
+    # Roots.0.Val 是基础类型 leaf
+    assert "Roots.0.Val" in unfold
+    assert unfold["Roots.0.Val"]["type"] == "String"
+    # Roots.0.Children.0 是自引用截断点，type 应被改写为 Object
+    assert "Roots.0.Children.0" in unfold
+    assert unfold["Roots.0.Children.0"]["type"] == "Object"
+    assert "self-referencing type" in unfold["Roots.0.Children.0"]["document"]
+    assert unfold["Roots.0.Children.0"].get("recursive_truncated") is True
+    assert unfold["Roots.0.Children.0"].get("recursive_type") == "Node"
+
+
+# ============================================================
+# G. 公共 API 端到端
+# ============================================================
+def test_G1_get_param_info_public():
+    """G1: get_param_info 公共方法签名 / 行为。"""
+    ld = _make_loader(_self_ref_list_model())
+    info = ld.get_param_info("svc", "v", "Tree")
+    assert "Root" in info
+
+
+def test_G2_get_output_param_info_public():
+    """G2: get_output_param_info 接受 Response。"""
+    objects = {
+        "TreeRequest": {"members": [
+            {"name": "X", "type": "string", "member": "string",
+             "document": "", "required": True}
+        ]},
+        "TreeResponse": {"members": [
+            {"name": "Y", "type": "string", "member": "string",
+             "document": "", "required": True}
+        ]},
+    }
+    actions = {"Tree": {"input": "TreeRequest", "output": "TreeResponse",
+                        "name": "Tree"}}
+    ld = _make_loader(_model(actions, objects))
+    out = ld.get_output_param_info("svc", "v", "Tree")
+    assert "Y" in out
+
+
+def test_G3_generate_param_skeleton_public():
+    """G3: generate_param_skeleton 公共方法 + 自引用字符串占位。"""
+    ld = _make_loader(_self_ref_list_model())
+    skeleton = ld.generate_param_skeleton("svc", "v", "Tree")
+    assert skeleton["Root"]["Children"] == [
+        "<recursive: fill 'Children' with a JSON object of type Node (self-referenced)>"
+    ]
+
+
+def test_G4_get_unfold_param_info_public():
+    """G4: get_unfold_param_info 公共方法。"""
+    ld = _make_loader(_self_ref_list_model())
+    unfold = ld.get_unfold_param_info("svc", "v", "Tree")
+    # 必须返回 dict，且 key 是点分路径
+    assert isinstance(unfold, dict)
+    assert all("." in k or k == "Root" for k in unfold.keys())
+
+
+# ============================================================
+# H. 真实仓库数据冒烟
+# ============================================================
+def test_H1_real_cvm_describe_instances_smoke():
+    """H1: 真实 cvm DescribeInstances 接口能正常生成展开参数。"""
+    ld = Loader()
+    try:
+        info = ld.get_param_info("cvm", "2017-03-12", "DescribeInstances")
+    except Exception as e:
+        pytest.skip("local cvm api.json missing: %s" % e)
+    assert isinstance(info, dict)
+    assert "InstanceIds" in info or "Filters" in info
+
+    unfold = ld.get_unfold_param_info("cvm", "2017-03-12", "DescribeInstances")
+    assert isinstance(unfold, dict)
+    assert len(unfold) > 0
+    # 普通接口不应出现自引用截断提示
+    for k, v in unfold.items():
+        assert "RecursiveRef" not in v.get("type_name", "")
+
+
+def test_H2_real_billing_self_ref_does_not_crash():
+    """H2: 真实 billing CreateAllocationRule（含 AllocationRuleExpression 自引用）
+    不再触发 RecursionError，且能产出 unfold 参数与 skeleton。"""
+    ld = Loader()
+    services_path = ld.get_services_path()
+    api_path = os.path.join(services_path, "billing", "v20180709", "api.json")
+    if not os.path.exists(api_path):
+        pytest.skip("local billing api.json missing")
+
+    # 选取一个含 AllocationRuleExpression 自引用的真实 action
+    candidates = ["CreateAllocationRule", "ModifyAllocationRule"]
+    chosen = None
+    for act in candidates:
+        try:
+            ld.get_action_model("billing", "2018-07-09", act)
+            chosen = act
+            break
+        except Exception:
+            continue
+    if chosen is None:
+        pytest.skip("no candidate self-ref action available")
+
+    # 1) get_param_info 不抛
+    info = ld.get_param_info("billing", "2018-07-09", chosen)
+    assert isinstance(info, dict)
+
+    # 2) generate_param_skeleton 应在自引用处出现字符串占位
+    skeleton = ld.generate_param_skeleton("billing", "2018-07-09", chosen)
+    flat = repr(skeleton)
+    assert "<recursive: fill " in flat
+    assert "(self-referenced)" in flat
+    assert "AllocationRuleExpression" in flat
+
+    # 3) get_unfold_param_info 不抛，且至少有一个截断标记字段
+    unfold = ld.get_unfold_param_info("billing", "2018-07-09", chosen)
+    assert isinstance(unfold, dict) and len(unfold) > 0
+    has_truncation_doc = any(
+        "self-referencing type" in (v.get("document") or "") for v in unfold.values()
+    )
+    assert has_truncation_doc, (
+        "expected at least one self-ref truncation marker in %s" % chosen
+    )
+    # 方案-B 稳定字段：至少一个截断 leaf 带 recursive_truncated=True
+    assert any(v.get("recursive_truncated") for v in unfold.values()), (
+        "expected at least one leaf with recursive_truncated=True in %s" % chosen
+    )
+
+
+# ============================================================
+# I. 简单 getter / 静态信息方法（覆盖 L65-L179、L248-L321 多处）
+# ============================================================
+def test_I1_get_services_path_returns_existing_dir():
+    """I1: get_services_path 应返回 tccli/services 真实目录。"""
+    ld = Loader()
+    p = ld.get_services_path()
+    assert os.path.isdir(p)
+    assert p.endswith("services")
+
+
+def test_I2_static_text_getters():
+    """I2: 文本类 getter 返回非空字符串。"""
+    ld = Loader()
+    assert isinstance(ld.get_cli_version(), str) and ld.get_cli_version()
+    assert "Tencent Cloud" in ld.get_description()
+    assert "tccli configure" in ld.get_configure()
+    assert "tccli" in ld.get_usage()
+
+
+def test_I3_get_options_and_cli_option_shape():
+    """I3: get_options / get_cli_option 返回正确结构。"""
+    ld = Loader()
+    opts = ld.get_options()
+    assert "help" in opts and "--version" in opts
+    cli_opt = ld.get_cli_option()
+    # 关键 cli 全局选项必须存在
+    for must in ("filter", "output", "secretId", "secretKey", "profile",
+                 "region", "endpoint", "generate-cli-skeleton",
+                 "cli-input-json", "cli-unfold-argument", "language"):
+        assert must in cli_opt, "missing global option: %s" % must
+    # output 限定 choices
+    assert set(cli_opt["output"]["choices"]) == {"json", "text", "table"}
+
+
+def test_I4_version_transform():
+    """I4: _version_transform 把 'v20180709' 还原为 '2018-07-09'。"""
+    ld = Loader()
+    assert ld._version_transform("v20180709") == "2018-07-09"
+    assert ld._version_transform("v20170312") == "2017-03-12"
+
+
+def test_I5_get_service_description_and_usage_options():
+    """I5: 服务级简单 getter 行为。"""
+    ld = _make_loader(_model(
+        actions={"X": _action("XRequest")},
+        objects={"XRequest": {"members": []}},
+    ))
+    # metadata 没有 api_brief 时返回空串
+    assert ld.get_service_description("svc", "v") == ""
+    assert "svc" in ld.get_service_usage("svc")
+    sopts = ld.get_service_options("svc")
+    assert "help" in sopts and "svc" in sopts["help"]
+
+
+def test_I6_get_action_simple_getters():
+    """I6: action 级简单 getter（description / online_status / usage / options）。"""
+    objects = {"FooRequest": {"members": []}}
+    actions = {"Foo": {"input": "FooRequest", "name": "Foo",
+                       "document": "doc-foo", "status": "deprecated"}}
+    ld = _make_loader(_model(actions, objects))
+
+    assert ld.get_action_description("svc", "v", "Foo") == "doc-foo"
+    assert ld.get_action_online_status("svc", "v", "Foo") == "deprecated"
+    # 未指定 status 时默认 online
+    actions["Bar"] = {"input": "FooRequest", "name": "Bar", "document": "d"}
+    assert ld.get_action_online_status("svc", "v", "Bar") == "online"
+
+    usage = ld.get_action_usage("svc", "Foo")
+    assert "tccli" in usage and "svc" in usage and "Foo" in usage
+
+    aopts = ld.get_action_options("svc", "Foo")
+    assert "--profile" in aopts
+
+
+def test_I7_get_action_model_and_actions_info():
+    """I7: get_action_model / get_actions_info 直接查 action 元数据。"""
+    actions = {
+        "B": {"input": "FooRequest", "name": "B", "document": "doc-b"},
+        "A": {"input": "FooRequest", "name": "A", "document": "doc-a"},
+    }
+    objects = {"FooRequest": {"members": []}}
+    ld = _make_loader(_model(actions, objects))
+
+    am = ld.get_action_model("svc", "v", "A")
+    assert am["name"] == "A" and am["document"] == "doc-a"
+
+    info = ld.get_actions_info("svc", "v")
+    # 返回 OrderedDict 且按 action name 排序
+    assert list(info.keys()) == ["A", "B"]
+    assert info["A"]["status"] == "online"  # 缺省值
+
+
+# ============================================================
+# J. get_service_model 真实读 + plugin merge 分支
+# ============================================================
+def test_J1_get_service_model_real_cvm():
+    """J1: 走真实磁盘路径读 cvm api.json（命中 L208-L246 主路径）。"""
+    ld = Loader()
+    services_path = ld.get_services_path()
+    api_path = os.path.join(services_path, "cvm", "v20170312", "api.json")
+    if not os.path.exists(api_path):
+        pytest.skip("local cvm api.json missing")
+    model = ld.get_service_model("cvm", "2017-03-12")
+    assert "actions" in model and "objects" in model
+    assert "DescribeInstancesRequest" in model["objects"]
+
+
+def test_J2_get_service_model_plugin_merge_branch():
+    """J2: 命中 plugin merge 分支（L228-L241），合并自定义 plugin actions/objects。"""
+    ld = Loader()
+    services_path = ld.get_services_path()
+    api_path = os.path.join(services_path, "cvm", "v20170312", "api.json")
+    if not os.path.exists(api_path):
+        pytest.skip("local cvm api.json missing")
+    # 注入一个伪 plugin，名字与 service 匹配，版本与 v20170312 匹配
+    fake_plugin_spec = {
+        "metadata": {"_plugin_marker": "yes"},
+        "actions": {"_FakePluginAction": {"name": "_FakePluginAction"}},
+        "objects": {"_FakePluginObject": {"members": []}},
+    }
+    saved = _plg.import_plugins
+    _plg.import_plugins = lambda: {"cvm": {"2017-03-12": fake_plugin_spec}}
+    try:
+        model = ld.get_service_model("cvm", "2017-03-12")
+        # plugin 合并的 metadata/actions/objects 都生效
+        assert model["metadata"].get("_plugin_marker") == "yes"
+        assert "_FakePluginAction" in model["actions"]
+        assert "_FakePluginObject" in model["objects"]
+    finally:
+        _plg.import_plugins = saved
+
+
+def test_J3_get_available_services_returns_dict():
+    """J3: get_available_services 返回 dict 且至少包含 cvm。"""
+    ld = Loader()
+    avail = ld.get_available_services()
+    assert isinstance(avail, dict)
+    if "cvm" in avail:
+        assert isinstance(avail["cvm"], list)
+
+
+# ============================================================
+# K. get_service_default_version / 多版本 / all-action 系列
+# ============================================================
+def test_K1_get_service_default_version_uses_first():
+    """K1: 无配置文件时默认取 available_services[service][0]。"""
+    ld = Loader()
+    # 屏蔽 ~/.tccli 读取
+    avail = ld.get_available_services()
+    if "cvm" not in avail or not avail["cvm"]:
+        pytest.skip("cvm not in available services")
+
+    # 用 monkey patch 让 file_existed 返回 False
+    from tccli import utils as _u
+    saved = _u.Utils.file_existed
+    _u.Utils.file_existed = staticmethod(lambda *a, **kw: (False, ""))
+    try:
+        ver = ld.get_service_default_version("cvm")
+        assert ver in avail["cvm"]
+    finally:
+        _u.Utils.file_existed = saved
+
+
+def test_K2_get_service_all_version_actions_real_cvm():
+    """K2: 真实 cvm 至少含一个版本目录。"""
+    ld = Loader()
+    services_path = ld.get_services_path()
+    cvm_path = os.path.join(services_path, "cvm")
+    if not os.path.isdir(cvm_path):
+        pytest.skip("local cvm dir missing")
+    res = ld.get_service_all_version_actions("cvm")
+    assert isinstance(res, dict) and len(res) > 0
+    # 任意一个 version 的 actions 是可迭代
+    any_ver = next(iter(res))
+    assert hasattr(res[any_ver], "__iter__")
+
+
+def test_K3_get_service_all_version_actions_missing_raises():
+    """K3: service 不存在时抛异常。"""
+    ld = Loader()
+    try:
+        ld.get_service_all_version_actions("__no_such_service__")
+        assert False, "expected exception"
+    except Exception as e:
+        assert "Not find service" in str(e)
+
+
+def test_K4_get_service_all_action_param_default_model():
+    """K4: 未指定 model 时走 get_param_info 分支。
+
+    单测约束：不依赖真实 cvm 服务数据，用内存注入的版本-动作映射驱动，
+    仅验证 dispatch 走 get_param_info（默认分支）。
+    """
+    ld = Loader()
+    ld.get_service_all_version_actions = lambda service: {"v": {"Foo"}}
+    ld.get_param_info = lambda s, v, a: {"Id": {}, "Name": {}}
+    ld.get_unfold_param_info = lambda *a, **kw: (_ for _ in ()).throw(
+        AssertionError("默认 model 不应走 get_unfold_param_info"))
+    res = ld.get_service_all_action_param("svc")
+    assert isinstance(res, dict)
+    assert "Foo" in res
+    assert set(res["Foo"]) == {"Id", "Name"}
+
+
+def test_K5_get_service_all_action_param_unfold_model():
+    """K5: model='cli-unfold-argument' 时走 get_unfold_param_info 分支。"""
+    ld = Loader()
+    ld.get_service_all_version_actions = lambda service: {"v": {"Foo"}}
+    ld.get_unfold_param_info = lambda s, v, a: {"Id": {}, "Tags.0": {}}
+    ld.get_param_info = lambda *a, **kw: (_ for _ in ()).throw(
+        AssertionError("unfold model 不应走 get_param_info"))
+    res = ld.get_service_all_action_param("svc", model="cli-unfold-argument")
+    assert isinstance(res, dict)
+    assert "Foo" in res
+    assert set(res["Foo"]) == {"Id", "Tags.0"}
+
+
+# ============================================================
+# L. _add_array_item / get_unfold_param_info 的 param_array 行为
+# ============================================================
+def test_L1_add_array_item_expand_to_max():
+    """L1: 路径含 '0' 占位时，会被复制为 0..arrayCount-1，默认 10 份。"""
+    ld = Loader()
+    # mock file_existed 返回 False，走默认 array_count=10
+    from tccli import utils as _u
+    saved = _u.Utils.file_existed
+    _u.Utils.file_existed = staticmethod(lambda *a, **kw: (False, ""))
+    try:
+        param_list = [["A", "0", "B"]]
+        out = ld._add_array_item(param_list, "default")
+        # 应包含 ["A","1","B"] ~ ["A","9","B"] 共 9 条新增（加原 1 条 = 10）
+        assert ["A", "0", "B"] in out
+        assert ["A", "9", "B"] in out
+        # 不应越界产生 "10"
+        assert ["A", "10", "B"] not in out
+    finally:
+        _u.Utils.file_existed = saved
+
+
+def test_L2_add_array_item_with_param_array_via_unfold():
+    """L2: 通过 get_unfold_param_info(param_array=True) 触发 _add_array_item。"""
+    ld = _make_loader(_self_ref_list_model())
+    # mock 配置以使用默认 array_count
+    from tccli import utils as _u
+    saved = _u.Utils.file_existed
+    _u.Utils.file_existed = staticmethod(lambda *a, **kw: (False, ""))
+    try:
+        unfold = ld.get_unfold_param_info(
+            "svc", "v", "Tree", profile="default", param_array=True)
+        # 应展开出 Root.Children.1, Root.Children.2 ... 等额外路径
+        assert "Root.Children.0" in unfold
+        # 至少有一个非 0 的下标 key
+        non_zero = [k for k in unfold if k.startswith("Root.Children.") and not k.endswith(".0")]
+        assert len(non_zero) > 0
+    finally:
+        _u.Utils.file_existed = saved
+
+
+# ============================================================
+# M. _filling_unfold_param_info 未覆盖分支
+# ============================================================
+def test_M1_filling_required_downgrade_in_path():
+    """M1: 路径中某层 required=Optional 时，最终 leaf required 也降为 Optional。"""
+    objects = {
+        "ZRequest": {
+            "members": [
+                {"name": "Outer", "type": "object", "member": "Inner",
+                 "document": "outer", "required": True},  # 顶层 Required
+            ],
+        },
+        "Inner": {
+            "members": [
+                {"name": "Mid", "type": "object", "member": "Leaf",
+                 "document": "mid", "required": False},  # ← 中间 Optional
+            ],
+        },
+        "Leaf": {
+            "members": [
+                {"name": "X", "type": "string", "member": "string",
+                 "document": "x", "required": True},
+            ],
+        },
+    }
+    ld = _make_loader(_model({"Z": _action("ZRequest")}, objects))
+    unfold = ld.get_unfold_param_info("svc", "v", "Z")
+    # Outer 顶层 Required，但中间 Mid Optional → 最终 leaf 也是 Optional
+    assert unfold["Outer.Mid.X"]["required"] == "Optional"
+
+
+def test_M2_filling_array_index_gt_zero_downgrades_required():
+    """M2: 路径中含 '1' '2' 等非零下标时 required 强制 Optional（覆盖 L540-L541）。"""
+    ld = _make_loader(_self_ref_list_model())
+    from tccli import utils as _u
+    saved = _u.Utils.file_existed
+    _u.Utils.file_existed = staticmethod(lambda *a, **kw: (False, ""))
+    try:
+        unfold = ld.get_unfold_param_info(
+            "svc", "v", "Tree", profile="default", param_array=True)
+        # Root.Children.1 等非零下标的 required 应是 Optional
+        for k, v in unfold.items():
+            if k.startswith("Root.Children.") and not k.endswith(".0"):
+                assert v["required"] == "Optional"
+                break
+    finally:
+        _u.Utils.file_existed = saved
+
+
+def test_M3_filling_path_traverses_array_member_dict():
+    """M3: 路径在 Array 类型节点上钻取（覆盖 L498 res['type']=='Array' 取 [0] 分支）。"""
+    objects = {
+        "ARequest": {
+            "members": [
+                {"name": "Items", "type": "list", "member": "Item",
+                 "document": "items", "required": True},
+            ],
+        },
+        "Item": {
+            "members": [
+                {"name": "Key", "type": "string", "member": "string",
+                 "document": "k", "required": True},
+                {"name": "Val", "type": "string", "member": "string",
+                 "document": "v", "required": False},
+            ],
+        },
+    }
+    ld = _make_loader(_model({"A": _action("ARequest")}, objects))
+    unfold = ld.get_unfold_param_info("svc", "v", "A")
+    # Items 是 Array → 钻取时走 res["members"][0][item] 分支
+    assert "Items.0.Key" in unfold
+    assert unfold["Items.0.Key"]["type"] == "String"
+    assert unfold["Items.0.Val"]["required"] == "Optional"
+
+
+# ============================================================
+# N. example / translate 系列
+# ============================================================
+def _patch_example_model(ld, examples):
+    """为 ld 注入伪 example data，供 generate_cli_example 调用。"""
+    ld.get_action_example_model = lambda s, v, a: examples
+
+
+def test_N1_get_action_example_model_missing_raises():
+    """N1: examples.json 不存在时抛异常。"""
+    ld = Loader()
+    try:
+        ld.get_action_example_model("__no_svc__", "1970-01-01", "X")
+        assert False
+    except Exception as e:
+        assert "Not find service" in str(e)
+
+
+def test_N2_get_action_example_model_real_cvm():
+    """N2: 真实 cvm DescribeInstances 应有 examples。"""
+    ld = Loader()
+    services_path = ld.get_services_path()
+    if not os.path.exists(os.path.join(services_path, "cvm", "v20170312", "examples.json")):
+        pytest.skip("examples.json missing")
+    ex = ld.get_action_example_model("cvm", "2017-03-12", "DescribeInstances")
+    assert isinstance(ex, list) and len(ex) > 0
+
+
+def test_N3_translate_get_cli_param_basic():
+    """N3: GET 参数解析 —— 简单 key=value、空格转义、List 索引去掉。"""
+    ld = Loader()
+    out = ld.translate_get_cli_param([
+        "Limit=10",
+        "Offset=0",
+        "Filters.0=foo",
+        "Filters.1=bar baz",
+    ])
+    # 简单 key
+    assert "--Limit 10" in out
+    assert "--Offset 0" in out
+    # List 索引被去掉，多值聚合，空格用引号包裹
+    filters = [s for s in out if s.startswith("--Filters")]
+    assert len(filters) == 1
+    assert "foo" in filters[0]
+    assert "'bar baz'" in filters[0]
+
+
+def test_N4_translate_get_cli_param_skip_invalid():
+    """N4: 无 '=' 的非法 token 应被忽略不抛异常。"""
+    ld = Loader()
+    out = ld.translate_get_cli_param(["Limit=10", "no_equals_token"])
+    assert any("--Limit" in s for s in out)
+
+
+def test_N5_translate_post_cli_param_complex():
+    """N5: POST JSON 入参翻译 —— 嵌套 object / list of object / 含空格值。"""
+    ld = Loader()
+    inp = {
+        "Name": "hello world",
+        "Count": 3,
+        "Tags": ["a", "b c"],
+        "Items": [
+            {"K": "k1", "V": "v 1"},
+            {"K": "k2", "V": "v2"},
+        ],
+    }
+    out = ld.translate_post_cli_param(inp)
+    flat = "\n".join(out)
+    # 简单字段
+    assert "--Name 'hello world'" in flat
+    assert "--Count 3" in flat
+    # 基础类型 list 整段 join
+    assert "--Tags" in flat and "'b c'" in flat
+    # object list 用下标点路径
+    assert "--Items.0.K k1" in flat
+    assert "--Items.1.V v2" in flat
+
+
+def test_N6_generate_cli_example_post_input():
+    """N6: generate_cli_example 的 POST 入参翻译。"""
+    ld = _make_loader(_model(
+        actions={"X": _action("XRequest")},
+        objects={"XRequest": {"members": []}},
+    ))
+    ld.get_action_example_model = lambda s, v, a: [
+        {
+            "input": "POST / HTTP/1.1\nHost: x.tencentcloudapi.com\n\n"
+                     '{"Name":"foo","N":1}',
+            "output": '{"Response":{"RequestId":"req-1"}}',
+            "title": "demo",
+        }
+    ]
+    examples = ld.generate_cli_example("svc", "v", "X")
+    assert len(examples) == 1
+    inp = examples[0]["input"]
+    assert any("--Name foo" in s for s in inp)
+    # output 经 json.dumps 美化（含换行）
+    assert "RequestId" in examples[0]["output"]
+
+
+def test_N7_generate_cli_example_get_input():
+    """N7: generate_cli_example 的 GET 入参翻译。"""
+    ld = _make_loader(_model(
+        actions={"X": _action("XRequest")},
+        objects={"XRequest": {"members": []}},
+    ))
+    ld.get_action_example_model = lambda s, v, a: [
+        {
+            "input": "https://x.tencentcloudapi.com/?Action=X"
+                     "&<公共请求参数>"
+                     "&Limit=10"
+                     "&Filters.0=foo",
+            "output": "not-json-but-ok",
+            "title": "demo-get",
+        }
+    ]
+    examples = ld.generate_cli_example("svc", "v", "X")
+    inp = examples[0]["input"]
+    assert any(s.startswith("--Limit") for s in inp)
+    assert any(s.startswith("--Filters") for s in inp)
+    # output 不是合法 JSON 时保持原样
+    assert examples[0]["output"] == "not-json-but-ok"
+
+
+def test_N8_translate_post_cli_param_basic_type_only():
+    """N8: 顶层是单一基础类型也能 happy path 走通 _translate_post_cli_param。"""
+    ld = Loader()
+    # 直接用底层私有方法验证 basic-type 短路分支
+    out = []
+    ld._translate_post_cli_param("hello", [], out)
+    assert out == [["hello"]]
+    # 含空格被引号包裹
+    out2 = []
+    ld._translate_post_cli_param("a b", [], out2)
+    assert out2 == [["'a b'"]]
+
+
+# ============================================================
+# O. 边界 / 异常 / 健壮性补充
+# ============================================================
+def test_O1_get_param_info_response_via_output_method():
+    """O1: get_output_param_info 在自引用类型上同样不崩溃。"""
+    objects = {
+        "TreeRequest": {"members": [
+            {"name": "A", "type": "string", "member": "string",
+             "document": "", "required": True}
+        ]},
+        "TreeResponse": {"members": [
+            {"name": "Root", "type": "object", "member": "Node",
+             "document": "", "required": True}
+        ]},
+        "Node": {"members": [
+            {"name": "Self", "type": "object", "member": "Node",
+             "document": "", "required": False},  # ← 自引用
+        ]},
+    }
+    actions = {"Tree": {"input": "TreeRequest", "output": "TreeResponse",
+                        "name": "Tree"}}
+    ld = _make_loader(_model(actions, objects))
+    out = ld.get_output_param_info("svc", "v", "Tree")
+    # Root 展开一层后 Self 是截断点
+    assert isinstance(out["Root"]["members"], dict)
+    assert out["Root"]["members"]["Self"]["members"] == "Node"
+
+
+def test_O2_unfold_basic_type_list_no_zero_in_path():
+    """O2: List<base_type> 不应在路径里 push '0'。"""
+    objects = {
+        "URequest": {"members": [
+            {"name": "Tags", "type": "list", "member": "string",
+             "document": "", "required": False}
+        ]},
+    }
+    ld = _make_loader(_model({"U": _action("URequest")}, objects))
+    unfold = ld.get_unfold_param_info("svc", "v", "U")
+    # 基础类型 list 路径只到字段名
+    assert "Tags" in unfold
+    # 不应注册 Tags.0 这种带 '0' 的路径
+    assert "Tags.0" not in unfold
+
+
+def test_O3_get_param_info_value_allowed_null_branch():
+    """O3: 字段含 value_allowed_null=True 时被正确写入。"""
+    objects = {"XRequest": {"members": [
+        {"name": "F", "type": "string", "member": "string",
+         "document": "", "required": True, "value_allowed_null": True}
+    ]}}
+    ld = _make_loader(_model({"X": _action("XRequest")}, objects))
+    info = ld.get_param_info("svc", "v", "X")
+    assert info["F"].get("value_allowed_null") == "AllowedNull"
+
+    # 反向：False 时为 NotAllowedNull
+    objects["XRequest"]["members"][0]["value_allowed_null"] = False
+    info2 = ld.get_param_info("svc", "v", "X")
+    assert info2["F"].get("value_allowed_null") == "NotAllowedNull"
+
+
+# ============================================================
+# P. 隔离契约：Request / Response 环结构不同的边界
+# ============================================================
+def test_P1_output_response_only_cycle_no_recursion():
+    """P1: Request 无环、Response 有环时，get_output_param_info 走 safe 路径不崩栈。"""
+    objects = {
+        "TreeRequest": {"members": [
+            {"name": "A", "type": "string", "member": "string",
+             "document": "", "required": True}
+        ]},
+        "TreeResponse": {"members": [
+            {"name": "Root", "type": "object", "member": "Node",
+             "document": "", "required": True}
+        ]},
+        "Node": {"members": [
+            {"name": "Self", "type": "object", "member": "Node",
+             "document": "", "required": False},  # ← 仅 Response 侧自引用
+        ]},
+    }
+    actions = {"Tree": {"input": "TreeRequest", "output": "TreeResponse",
+                        "name": "Tree"}}
+    ld = _make_loader(_model(actions, objects))
+    # 不应 RecursionError；Self 应被截断为字符串占位
+    out = ld.get_output_param_info("svc", "v", "Tree")
+    assert isinstance(out["Root"]["members"], dict)
+    assert out["Root"]["members"]["Self"]["members"] == "Node"
+
+
+def test_P2_input_side_unaffected_by_response_cycle():
+    """P2: 仅 Response 有环时，输入侧（get_param_info）仍走原始路径，输出与常规一致。"""
+    objects = {
+        "TreeRequest": {"members": [
+            {"name": "A", "type": "string", "member": "string",
+             "document": "", "required": True}
+        ]},
+        "TreeResponse": {"members": [
+            {"name": "Root", "type": "object", "member": "Node",
+             "document": "", "required": True}
+        ]},
+        "Node": {"members": [
+            {"name": "Self", "type": "object", "member": "Node",
+             "document": "", "required": False},
+        ]},
+    }
+    actions = {"Tree": {"input": "TreeRequest", "output": "TreeResponse",
+                        "name": "Tree"}}
+    ld = _make_loader(_model(actions, objects))
+    info = ld.get_param_info("svc", "v", "Tree")
+    # Request 侧只有基础类型字段 A，且 members 为原始字符串（非截断占位）
+    assert info["A"]["members"] == "string"
+    assert set(info.keys()) == {"A"}
+
+
+# ============================================================
+# 允许直接 `python3 tests/test_loaders.py` 运行（无 pytest 环境）
+# ============================================================
+if __name__ == "__main__":
+    import traceback
+
+    tests = [
+        (name, obj) for name, obj in sorted(globals().items())
+        if name.startswith("test_") and callable(obj)
+    ]
+    passed = failed = skipped = 0
+    failures = []
+    for name, fn in tests:
+        try:
+            fn()
+            print("PASS  %s" % name)
+            passed += 1
+        except Exception as e:
+            cls = e.__class__.__name__
+            if cls in ("_SkipException", "Skipped"):
+                print("SKIP  %s  (%s)" % (name, e))
+                skipped += 1
+            else:
+                print("FAIL  %s" % name)
+                traceback.print_exc()
+                failed += 1
+                failures.append(name)
+    print("\n=========================================")
+    print("total=%d  passed=%d  failed=%d  skipped=%d"
+          % (len(tests), passed, failed, skipped))
+    if failures:
+        print("failed tests:")
+        for n in failures:
+            print("  - %s" % n)
+    sys.exit(1 if failed else 0)

--- a/tests/test_self_ref.py
+++ b/tests/test_self_ref.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""
+针对 tccli/self_ref.py 环检测器的单元测试。
+
+覆盖检测器的能力契约（不依赖任何 SDK / 真实 api.json）：
+  A. _dfs_has_cycle 各种环形态：直接自环、间接环、多级环、无环、基础类型脱离。
+  B. is_action_self_referencing 的 Request / Response 双入口口径。
+  C. 异常兜底 fallback False。
+"""
+import os
+import sys
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    pass
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_TESTS_DIR)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from tccli.self_ref import (  # noqa: E402
+    _dfs_has_cycle, is_action_self_referencing,
+)
+
+
+def _obj(members):
+    return {"members": members}
+
+
+def _m(name, type_, member, required=True):
+    return {"name": name, "type": type_, "member": member,
+            "document": "", "required": required}
+
+
+# ============================================================
+# A. _dfs_has_cycle 环形态
+# ============================================================
+def test_A1_direct_self_cycle():
+    """A→A：类型直接引用自身。"""
+    objects = {"A": _obj([_m("Self", "object", "A", False)])}
+    assert _dfs_has_cycle(objects, "A", frozenset(["A"])) is True
+
+
+def test_A2_indirect_cycle():
+    """A→B→A：两级间接环。"""
+    objects = {
+        "A": _obj([_m("ToB", "object", "B")]),
+        "B": _obj([_m("ToA", "object", "A", False)]),
+    }
+    assert _dfs_has_cycle(objects, "A", frozenset(["A"])) is True
+
+
+def test_A3_multi_level_cycle():
+    """A→B→C→A：多级环。"""
+    objects = {
+        "A": _obj([_m("ToB", "object", "B")]),
+        "B": _obj([_m("ToC", "object", "C")]),
+        "C": _obj([_m("ToA", "object", "A", False)]),
+    }
+    assert _dfs_has_cycle(objects, "A", frozenset(["A"])) is True
+
+
+def test_A4_no_cycle_linear_chain():
+    """A→B→C→(string)：线性无环。"""
+    objects = {
+        "A": _obj([_m("ToB", "object", "B")]),
+        "B": _obj([_m("ToC", "object", "C")]),
+        "C": _obj([_m("Leaf", "string", "string")]),
+    }
+    assert _dfs_has_cycle(objects, "A", frozenset(["A"])) is False
+
+
+def test_A5_base_type_breaks_traversal():
+    """基础类型成员不追索，不误判为环。"""
+    objects = {
+        "A": _obj([
+            _m("Id", "string", "string"),
+            _m("Count", "int", "int64", False),
+        ]),
+    }
+    assert _dfs_has_cycle(objects, "A", frozenset(["A"])) is False
+
+
+def test_A6_list_member_cycle():
+    """List<A> 形式的自引用（如 Node.Children: list of Node）。"""
+    objects = {
+        "Node": _obj([
+            _m("Val", "string", "string"),
+            _m("Children", "list", "Node", False),
+        ]),
+    }
+    assert _dfs_has_cycle(objects, "Node", frozenset(["Node"])) is True
+
+
+def test_A7_diamond_no_cycle():
+    """菱形共享类型但无环：A→B→D, A→C→D，D 为叶子。"""
+    objects = {
+        "A": _obj([_m("ToB", "object", "B"), _m("ToC", "object", "C")]),
+        "B": _obj([_m("ToD", "object", "D")]),
+        "C": _obj([_m("ToD", "object", "D")]),
+        "D": _obj([_m("Leaf", "string", "string")]),
+    }
+    assert _dfs_has_cycle(objects, "A", frozenset(["A"])) is False
+
+
+# ============================================================
+# B. is_action_self_referencing 双入口口径
+# ============================================================
+def _model_request_cycle_only():
+    """Request 有环、Response 无环。"""
+    return {"objects": {
+        "TreeRequest": _obj([_m("Root", "object", "Node")]),
+        "TreeResponse": _obj([_m("Ok", "string", "string")]),
+        "Node": _obj([_m("Self", "object", "Node", False)]),
+    }}
+
+
+def _model_response_cycle_only():
+    """Request 无环、Response 有环。"""
+    return {"objects": {
+        "TreeRequest": _obj([_m("A", "string", "string")]),
+        "TreeResponse": _obj([_m("Root", "object", "Node")]),
+        "Node": _obj([_m("Self", "object", "Node", False)]),
+    }}
+
+
+def test_B1_request_side_detects_request_cycle():
+    model = _model_request_cycle_only()
+    assert is_action_self_referencing("s", "v", "Tree", model) is True
+    # 默认 root_suffix="Request"
+    assert is_action_self_referencing(
+        "s", "v", "Tree", model, root_suffix="Request") is True
+
+
+def test_B2_request_side_ignores_response_cycle():
+    """Request 无环时，输入侧默认判定为 False（即便 Response 有环）。"""
+    model = _model_response_cycle_only()
+    assert is_action_self_referencing("s", "v", "Tree", model) is False
+
+
+def test_B3_response_side_detects_response_cycle():
+    """输出侧显式传 root_suffix='Response'，可检出 Response 环。"""
+    model = _model_response_cycle_only()
+    assert is_action_self_referencing(
+        "s", "v", "Tree", model, root_suffix="Response") is True
+
+
+def test_B4_response_side_ignores_request_cycle():
+    model = _model_request_cycle_only()
+    assert is_action_self_referencing(
+        "s", "v", "Tree", model, root_suffix="Response") is False
+
+
+# ============================================================
+# C. 异常兜底
+#
+# _dfs_has_cycle 本身只专注判环、不做防御性判断；坏数据（缺 objects/根类型/
+# 悬空引用/members 非法）统一由 is_action_self_referencing 的 try/except 兜底为 False。
+# 本组用例即验证这条外层容错契约。
+# ============================================================
+def test_C1_missing_objects_key_returns_false():
+    assert is_action_self_referencing("s", "v", "X", {}) is False
+
+
+def test_C2_none_service_model_returns_false():
+    assert is_action_self_referencing("s", "v", "X", None) is False
+
+
+def test_C3_missing_root_type_returns_false():
+    """action 对应的根类型在 objects 中缺失时返回 False。"""
+    model = {"objects": {"OtherRequest": _obj([_m("A", "string", "string")])}}
+    assert is_action_self_referencing("s", "v", "Tree", model) is False
+
+
+def test_C4_dangling_reference_returns_false():
+    """悬空引用：字段 member 指向 objects 中不存在的类型，外层兜底为 False。"""
+    model = {"objects": {
+        "TreeRequest": _obj([_m("Root", "object", "NotThere", False)]),
+    }}
+    assert is_action_self_referencing("s", "v", "Tree", model) is False
+
+
+def test_C5_members_not_list_returns_false():
+    """脏数据：根类型 members 非 list，外层兜底为 False。"""
+    model = {"objects": {"TreeRequest": {"members": "not-a-list"}}}
+    assert is_action_self_referencing("s", "v", "Tree", model) is False
+
+
+def test_C6_non_dict_member_returns_false():
+    """脏数据：members 中混入非 dict 元素，外层兜底为 False。"""
+    model = {"objects": {"TreeRequest": {"members": ["garbage", 123]}}}
+    assert is_action_self_referencing("s", "v", "Tree", model) is False
+
+
+if __name__ == "__main__":
+    import pytest as _pt
+    sys.exit(_pt.main([os.path.abspath(__file__), "-v"]))


### PR DESCRIPTION
## 变更内容

修复数据结构自引用导致的无限递归，优化自引用占位提示并新增相关单元测试。

1. 新增 MAX_INPUT_DEPTH 等常量，在 loaders 模块增加 visited 参数实现自引用检测与截断。
2. 在 command 模块新增深嵌套参数识别、自引用提示生成等逻辑，调整参数解析流程。
3. 优化 document_handler 自引用截断渲染逻辑，调整复杂对象展开前置判断与递归条件。
4. 新增 cli_unfold_argument 的 extra_unfold_args 参数支持，优化参数合并处理逻辑。
5. 新增 self_ref 模块，抽出自引用检测器隔离链路并优化补偿逻辑。
6. 自引用截断点以下的 list 字段自动包装为数组，避免类型不匹配。
7. 新增 test_loaders、test_command、test_self_ref 等测试文件，覆盖自引用、深嵌套、参数解析等核心逻辑。